### PR TITLE
Avoid concatenation with nil

### DIFF
--- a/subs2srs.lua
+++ b/subs2srs.lua
@@ -403,11 +403,13 @@ end
 
 local function join_media_fields(note1, note2)
     if note2[config.audio_field] then
-        note1[config.audio_field] = note2[config.audio_field] .. note1[config.audio_field]
+        note1[config.audio_field] = note2[config.audio_field] .. (note1[config.audio_field] == nil and "" or note1[config.audio_field])
     end
+
     if note2[config.image_field] then
-        note1[config.image_field] = note2[config.image_field] .. note1[config.image_field]
+        note1[config.image_field] = note2[config.image_field] .. (note1[config.image_field] == nil and "" or note1[config.image_field])
     end
+
     return note1
 end
 


### PR DESCRIPTION
Currently incorrectly assumes that `note1` will always have media, this causes it to crash if it doesn't due to concatenating with nil.
This issue wasn't as obvious since it would require Yomichan to not have a reading for the word which is rare.

Also other issues are:
- assuming that users will have opus or mp3 (mac builds don't include them), rather mpvacious should be able to use `mpv -ovc=help` and `mpv -oac=help` and parse out valid video and audio codecs.
- only checking one location for the Anki collection on Mac since it could also be found `~/Library/Application Support/Anki2/User 1/collection.media` both should be checked