### PR TITLE
Escape ampersand char for Windows

### DIFF
--- a/subs2srs.lua
+++ b/subs2srs.lua
@@ -612,6 +612,7 @@ local function init_platform_windows()
     end
 
     self.copy_to_clipboard = function(text)
+        text = text:gsub("&", "^^^&")
         mp.commandv("run", "cmd.exe", "/d", "/c", string.format("@echo off & chcp 65001 & echo %s|clip", text))
     end
 


### PR DESCRIPTION
Ampersand characters in subtitles causes issues because it is a reserved character in cmd, so we need to escape them.
https://stackoverflow.com/a/35578027/10625876