### PR TITLE
Add --create-dirs to curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ mpvacious can be installed with the [mpv-mpvacious](https://aur.archlinux.org/pa
 ### Using curl
 
 ```
-$ curl -o ~/.config/mpv/scripts/subs2srs.lua 'https://raw.githubusercontent.com/Ajatt-Tools/mpvacious/master/subs2srs.lua'
+$ curl -o ~/.config/mpv/scripts/subs2srs.lua --create-dirs 'https://raw.githubusercontent.com/Ajatt-Tools/mpvacious/master/subs2srs.lua'
 ```
 
 ### Using git


### PR DESCRIPTION
Without [--create-dirs](https://curl.se/changes.html#7_10_3) `curl` throws if directory doesn't exist. I think with `--create-dirs` its much more user friendly for people just copy pasting commands hoping for the best. Tested on macOS 11.1 and curl 7.64.1

```
❯ curl -o ~/.config/mpv/scripts/subs2srs.lua 'https://raw.githubusercontent.com/Ajatt-Tools/mpvacious/master/subs2srs.lua'
Warning: /Users/kolpav/.config/mpv/scripts/subs2srs.lua: No such file or
Warning: directory
  1 45865    1   856    0     0   3079      0  0:00:14 --:--:--  0:00:14  3079
curl: (23) Failed writing body (0 != 856)
```