### PR TITLE
Allow configuration of note update order

### DIFF
--- a/.github/RELEASE/subs2srs.conf
+++ b/.github/RELEASE/subs2srs.conf
@@ -41,6 +41,9 @@ tie_volumes=no
 # before copying subtitles to the clipboard
 clipboard_trim_enabled=yes
 
+# Add media to fields before or after existing data
+append_media=yes
+
 ##################
 # Image settings #
 ##################

--- a/subs2srs.lua
+++ b/subs2srs.lua
@@ -56,7 +56,8 @@ local config = {
     sentence_field = "SentKanji",
     audio_field = "SentAudio",
     image_field = "Image",
-    note_tag = "subs2srs",      -- the tag that is added to new notes. change to "" to disable tagging
+    note_tag = "subs2srs",         -- the tag that is added to new notes. change to "" to disable tagging
+    append_media = true,           -- True to append video media after existing data, false to insert media before
 
     -- Forvo support
     use_forvo = "yes",                  -- 'yes', 'no', 'always'
@@ -560,7 +561,11 @@ local function update_last_note(overwrite)
         new_data = append_forvo_pronunciation(new_data, stored_data)
         new_data = update_sentence(new_data, stored_data)
         if not overwrite then
-            new_data = join_media_fields(new_data, stored_data)
+            if config.append_media then
+                new_data = join_media_fields(new_data, stored_data)
+            else
+                new_data = join_media_fields(stored_data, new_data)
+            end
         end
     end
 


### PR DESCRIPTION
Adds an option, append_media(default=true) that allows one to configure whether media gets added before or after the existing card data.