### PR TITLE
anki: add miscinfo_field and miscinfo_format

### DIFF
--- a/.github/RELEASE/subs2srs.conf
+++ b/.github/RELEASE/subs2srs.conf
@@ -12,6 +12,12 @@ model_name=Japanese sentences
 sentence_field=SentKanji
 audio_field=SentAudio
 image_field=Image
+miscinfo_field=Notes
+
+# Format string used to fill the miscinfo_field. It supports the same
+# substitutions as note_tag. HTML is supported.
+miscinfo_format=%n (%t)
+#miscinfo_format=From <b>mpvacious</b> %n at %t.
 
 # The tag(s) added to new notes. Spaces separate multiple tags.
 # Leave nothing after `=` to disable tagging completely.


### PR DESCRIPTION
It is useful to know where exactly a card came from, and the only way of
doing this before this patch was to use the note_tag config option and
tag each note with the name of the video. However, in Anki tags are
quite annoying to use (and they clutter up the side-bar). In addition,
you wouldn't easily be able to show the source information from the tag
in a way that is different to the regular "yomichan subs2srs" tags.

To solve this, add a new card field (miscinfo_field) that can be used to
store the source information of the clip. It accepts the same format
strings as note_tag (miscinfo_format).

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>

