### PR TITLE
add functionality to manage ep numbers in tags

### DIFF
--- a/.github/RELEASE/subs2srs.conf
+++ b/.github/RELEASE/subs2srs.conf
@@ -24,6 +24,7 @@ miscinfo_format=%n (%t)
 # The following substitutions are supported:
 #   %n - the name of the video
 #   %t - timestamp
+#   %d - episode number (if none, returns nothing)
 #   %e - SUBS2SRS_TAGS environment variable
 note_tag=subs2srs
 #note_tag=%n %t %e
@@ -60,6 +61,12 @@ append_media=yes
 
 # Remove text in brackets before substituting %n into tag
 tag_nuke_brackets=yes
+
+# Remove text in brackets before substituting %n into tag
+tag_nuke_parentheses=no
+
+# Remove the episode number before substituting %n into tag
+tag_del_episode_num=no
 
 ##################
 # Image settings #


### PR DESCRIPTION
add functionality to manage ep numbers in tags

With this addition users are able to save the number of the episode (substitution %d in miscinfo_field) and the name of the series separately (only when tag_del_episode_num=yes, it's disabled by default).

This can help keeping tags from one series the same throughout its episodes without cluttering Anki's browser.

For example: I have a field called SequenceMarker in my cards formatted like this: epnum_00m00s000ms (e.g. 01_12m30s432ms) and as a tag only the name of the series (e.g. Puella_Magi_Madoka_Magica) without the episode number.

In addition, I added a new option called 'tag_nuke_parentheses' which can be used to delete all text inside parentheses before subsituting filename into the tag (function: remove_filename_text_in_parentheses). I found out that this makes the tags a lot more consistent and clean. This is disabled by default.

Some files I tested the code with (release groups censored):
- `(Hi10)_Kobayashi-san_Chi_no_Maid_Dragon_-_02_(BD_1080p)_(*******)_(12C5D2B4).mkv` -> `Kobayashi-san_Chi_no_Maid_Dragon` with ep num. of `02`
- `[*******] Koi to Yobu ni wa Kimochi Warui - 01 (1080p) [D517C9F0].mkv` -> `Koi_to_Yobu_ni_wa_Kimochi_Warui` with ep. num. of `01`
- `[*******] Tsukimonogatari 01 [BD 1080p x264 10-bit FLAC] [5CD88145].mkv` -> `Tsukimonogatari` with ep. num. of `01`
- `[*******] 86 - Eighty Six - 01 (1080p) [1B13598F].mkv` -> `86_Eighty_Six` with ep. num. of `01`
- `[*******] Fate Stay Night - Unlimited Blade Works - 00 (BD 1080p Hi10 FLAC) [95590B7F].mkv` -> `Fate_Stay_Night_Unlimited_Blade_Works` with ep. num. of `00`
- `House, M.D. S01E01 Pilot - Everybody Lies (1080p x265 *******).mkv` -> `House,_M.D._S01` with ep. num. of `01`
- `A Whisker Away.mkv` -> `A_Whisker_Away` with no ep. num.
- `[*******] Gekijouban SHIROBAKO [Ma10p_1080p][x265_flac].mkv` -> `Gekijouban_SHIROBAKO` with no ep. num.

PS: As this is my first time writing Lua, there might some silly style mistakes!
