### PR TITLE
fixed some regressions when deleting the episode number and added a new option

### DIFF
--- a/.github/RELEASE/subs2srs.conf
+++ b/.github/RELEASE/subs2srs.conf
@@ -68,6 +68,10 @@ tag_nuke_parentheses=no
 # Remove the episode number before substituting %n into tag
 tag_del_episode_num=yes
 
+# Remove everything after the episode number before substituting %n into tag
+# Does nothing if the previous option tag_del_episode_num is disabled.
+tag_del_after_episode_num=yes
+
 # Convert filename to lowercase for tagging.
 tag_filename_lowercase=no
 

--- a/subs2srs.lua
+++ b/subs2srs.lua
@@ -318,14 +318,14 @@ local function get_episode_number(filename)
 end
 
 local function tag_format(filename)
+    filename = remove_extension(filename)
+    filename = remove_common_resolutions(filename)
+
     local episode = get_episode_number(filename)
 
     if config.tag_del_episode_num == true then
         filename = filename:gsub(episode, '')
     end
-
-    filename = remove_extension(filename)
-    filename = remove_common_resolutions(filename)
 
     if config.tag_nuke_brackets == true then
         filename = remove_text_in_brackets(filename)


### PR DESCRIPTION
Firstly, great job cleaning up my code 😅! Just a couple regressions I found:

#### 1:
I moved the `remove_extension` and `remove_common_resolutions` at the beginning of the `tag_format` function _before_ `get_episode_number` as the function prefers the filename without the extension and resolution. 


#### 2:
Deleting the episode number is actually pretty delicate process: Gsub isn't perfect for this as it's going to delete every found instance in the string (like the season number or numbers in the name of the series). This can be fixed by reversing the string again and limiting gsub deleting just the first found instance like this: `filename:gsub(episode, '', 1)`. But IMHO it's better that we delete the episode number _and_ everything after that as in some cases the filename contains the episode name too. 

The regressed implementation parsed this `House, M.D. S01E01 Pilot - Everybody Lies (1080p x265 *****)` like this `House,_M.D._SE_Pilot_Everybody_Lies)`. It should be `House,_M.D._S01` without the episode name (Pilot - Everybody Lies) and with the season (S01) still intact.

I've fixed this by returning a second variable from `get_episode_number` which marks the place where the episode number starts in the string. But I've also added a new option called `tag_del_after_episode_num` which can be used to just delete the episode number without anything else as some people might prefer this. I had to do some string reversing there as almost always the last number is the ep num.

Some comparisons (tested with tag_nuke_parentheses enabled and disabled):
- Original filename: `House, M.D. S01E01 Pilot - Everybody Lies (1080p x265 *****)`
- Before this pull request: `House,_M.D._SE_Pilot_Everybody_Lies) EP01 (30m20s131ms)`
- After this pull request with `tag_del_after_episode_num` enabled: `House,_M.D._S01 EP01 (30m20s131ms)`
- After this pull request with `tag_del_after_episode_num` disabled: `House,_M.D._S01E_Pilot_Everybody_Lies EP01 (30m20s131ms)`

I also tested my changes again with the same files as in the [first pull request](https://github.com/Ajatt-Tools/mpvacious/pull/40).
