### PR TITLE
Fix automatic clipboard paste vulnerability

### DIFF
--- a/subs2srs.lua
+++ b/subs2srs.lua
@@ -825,8 +825,8 @@ local function init_platform_windows()
     end
 
     self.copy_to_clipboard = function(text)
-        text = text:gsub("&", "^^^&"):gsub("[<>]", "")
-        mp.commandv("run", "cmd.exe", "/d", "/c", string.format("@echo off & chcp 65001 & echo %s|clip", text))
+        text = text:gsub("&", "^^^&"):gsub("[<>|]", "")
+        mp.commandv("run", "cmd.exe", "/d", "/c", string.format("@echo off & chcp 65001 >null & echo %s|clip", text))
     end
 
     self.curl_request = function(request_json, completion_fn)


### PR DESCRIPTION
This patch removes any | characters from the subtitle string which is
going to be copied to clipboard on Windows, because they cannot be
reliably escaped and are interpreted as pipe operator.  Before this
change, it was possible to put `|notepad.exe` at the end of any subtitle
line in an external subtitle and have Notepad open.  While it is highly
unlikely that this vulnerability would ever be used for a real attack,
it still shouldn't be there.

Additionally, `chcp 65001 >null` removes `Active code page: 65001` flood
from stdout.