### PR TITLE
Fix a crash in subs.get_current

### DIFF
--- a/subs2srs.lua
+++ b/subs2srs.lua
@@ -1237,11 +1237,16 @@ subs = {
 subs.get_current = function()
     local sub_text = mp.get_property("sub-text")
     if not is_empty(sub_text) then
+        local sub_start = mp.get_property_number("sub-start")
+        local sub_end = mp.get_property_number("sub-end")
+        if sub_start == nil or sub_end == nil then
+            return nil
+        end
         local delay = mp.get_property_native("sub-delay") - mp.get_property_native("audio-delay")
         return Subtitle:new {
             ['text'] = sub_text,
-            ['start'] = mp.get_property_number("sub-start") + delay,
-            ['end'] = mp.get_property_number("sub-end") + delay
+            ['start'] = sub_start + delay,
+            ['end'] = sub_end + delay
         }
     end
     return nil


### PR DESCRIPTION
In mpv, Lua scripts run in their own threads in parallel to the main
playback thread.  Rarely, if `subs.get_current` is called at a time when
a subtitle line is about to go out, `mp.get_property("sub-text")` would
return a proper value, but then the subtitle would disappear and
`mp.get_property_number("sub-start")` would return `nil`.
Consequentially, Lua would throw an error "attempt to perform arithmetic
on a nil value" and end the script.  This patch ensures that all three
values are present before constructing a new `sub` object.