### PR TITLE
Fix incorrect redirect

### DIFF
--- a/subs2srs.lua
+++ b/subs2srs.lua
@@ -826,7 +826,7 @@ local function init_platform_windows()
 
     self.copy_to_clipboard = function(text)
         text = text:gsub("&", "^^^&"):gsub("[<>|]", "")
-        mp.commandv("run", "cmd.exe", "/d", "/c", string.format("@echo off & chcp 65001 >null & echo %s|clip", text))
+        mp.commandv("run", "cmd.exe", "/d", "/c", string.format("@echo off & chcp 65001 >nul & echo %s|clip", text))
     end
 
     self.curl_request = function(request_json, completion_fn)


### PR DESCRIPTION
Unfortunately I made a silly mistake in #57 which caused the output to be redirected to a plain file named "null" in current directory, which I didn't notice before making the PR.