### PR TITLE
Image attributes setting

### DIFF
--- a/.github/RELEASE/subs2srs.conf
+++ b/.github/RELEASE/subs2srs.conf
@@ -16,6 +16,11 @@ secondary_field=SentEng
 audio_field=SentAudio
 image_field=Image
 
+# Additional attributes added to the image field.
+# Adding data-editor-shrink="true" makes the image smaller on newer anki versions.
+image_attributes=alt="snapshot"
+#image_attributes=alt="snapshot" data-editor-shrink="true"
+
 # The tag(s) added to new notes. Spaces separate multiple tags.
 # Leave nothing after `=` to disable tagging completely.
 # The following substitutions are supported:

--- a/.github/RELEASE/subs2srs.conf
+++ b/.github/RELEASE/subs2srs.conf
@@ -119,11 +119,12 @@ snapshot_height=200
 # When using this, a custom sync server is recommended, e.g. https://github.com/ankicommunity/anki-sync-server
 screenshot=no
 
-# Additional attributes added to the image field.
+# The exact image template used when exporting to Anki's image field.
 # Adding data-editor-shrink="true" makes the image smaller by default within the Anki viewer
-# on versions 2.1.53+ (equivalent of double-clicking on the image)
-image_attributes=alt="snapshot"
-#image_attributes=alt="snapshot" data-editor-shrink="true"
+# on versions 2.1.53+ (equivalent of double-clicking on the image).
+# You likely would not want to change this unless you know what you are doing.
+image_template=<img alt="snapshot" src="%s">
+#image_template=<img alt="snapshot" data-editor-shrink="true" src="%s">
 
 ##################
 # Audio settings #

--- a/.github/RELEASE/subs2srs.conf
+++ b/.github/RELEASE/subs2srs.conf
@@ -120,7 +120,7 @@ snapshot_height=200
 screenshot=no
 
 # Additional attributes added to the image field.
-# Adding data-editor-shrink="true" makes the image smaller on newer anki versions.
+# Adding data-editor-shrink="true" makes the image smaller on Anki versions 2.1.53+
 image_attributes=alt="snapshot"
 #image_attributes=alt="snapshot" data-editor-shrink="true"
 

--- a/.github/RELEASE/subs2srs.conf
+++ b/.github/RELEASE/subs2srs.conf
@@ -120,7 +120,8 @@ snapshot_height=200
 screenshot=no
 
 # Additional attributes added to the image field.
-# Adding data-editor-shrink="true" makes the image smaller on Anki versions 2.1.53+
+# Adding data-editor-shrink="true" makes the image smaller by default within the Anki viewer
+# on versions 2.1.53+ (equivalent of double-clicking on the image)
 image_attributes=alt="snapshot"
 #image_attributes=alt="snapshot" data-editor-shrink="true"
 

--- a/.github/RELEASE/subs2srs.conf
+++ b/.github/RELEASE/subs2srs.conf
@@ -16,11 +16,6 @@ secondary_field=SentEng
 audio_field=SentAudio
 image_field=Image
 
-# Additional attributes added to the image field.
-# Adding data-editor-shrink="true" makes the image smaller on newer anki versions.
-image_attributes=alt="snapshot"
-#image_attributes=alt="snapshot" data-editor-shrink="true"
-
 # The tag(s) added to new notes. Spaces separate multiple tags.
 # Leave nothing after `=` to disable tagging completely.
 # The following substitutions are supported:
@@ -123,6 +118,11 @@ snapshot_height=200
 # 'snapshot_format' is still respected.
 # When using this, a custom sync server is recommended, e.g. https://github.com/ankicommunity/anki-sync-server
 screenshot=no
+
+# Additional attributes added to the image field.
+# Adding data-editor-shrink="true" makes the image smaller on newer anki versions.
+image_attributes=alt="snapshot"
+#image_attributes=alt="snapshot" data-editor-shrink="true"
 
 ##################
 # Audio settings #

--- a/subs2srs.lua
+++ b/subs2srs.lua
@@ -273,11 +273,11 @@ local function construct_note_fields(sub_text, secondary_text, snapshot_filename
         ret[config.secondary_field] = secondary_text
     end
     if not h.is_empty(config.image_field) then
-        local attributes = config.image_attributes
-        if not h.is_empty(attributes) then
-            attributes = " " .. attributes
+        if h.is_empty(config.image_attributes) then
+            ret[config.image_field] = string.format('<img src="%s">', snapshot_filename)
+        else
+            ret[config.image_field] = string.format('<img %s src="%s">', config.image_attributes, snapshot_filename)
         end
-        ret[config.image_field] = string.format('<img%s src="%s">', attributes, snapshot_filename)
     end
     if not h.is_empty(config.audio_field) then
         ret[config.audio_field] = string.format('[sound:%s]', audio_filename)

--- a/subs2srs.lua
+++ b/subs2srs.lua
@@ -70,6 +70,7 @@ local config = {
     secondary_field = "SentEng",
     audio_field = "SentAudio",
     image_field = "Image",
+    image_attributes = 'alt="snapshot"', -- Additional image attributes to add to Anki
     append_media = true, -- True to append video media after existing data, false to insert media before
     disable_gui_browse = false, -- Lets you disable anki browser manipulation by mpvacious.
 
@@ -272,7 +273,11 @@ local function construct_note_fields(sub_text, secondary_text, snapshot_filename
         ret[config.secondary_field] = secondary_text
     end
     if not h.is_empty(config.image_field) then
-        ret[config.image_field] = string.format('<img alt="snapshot" src="%s">', snapshot_filename)
+        local attributes = config.image_attributes
+        if not h.is_empty(attributes) then
+            attributes = " " .. attributes
+        end
+        ret[config.image_field] = string.format('<img%s src="%s">', attributes, snapshot_filename)
     end
     if not h.is_empty(config.audio_field) then
         ret[config.audio_field] = string.format('[sound:%s]', audio_filename)

--- a/subs2srs.lua
+++ b/subs2srs.lua
@@ -70,7 +70,7 @@ local config = {
     secondary_field = "SentEng",
     audio_field = "SentAudio",
     image_field = "Image",
-    image_attributes = 'alt="snapshot"', -- Additional image attributes to add to Anki
+    image_template = '<img alt="snapshot" src="%s">',
     append_media = true, -- True to append video media after existing data, false to insert media before
     disable_gui_browse = false, -- Lets you disable anki browser manipulation by mpvacious.
 
@@ -273,11 +273,7 @@ local function construct_note_fields(sub_text, secondary_text, snapshot_filename
         ret[config.secondary_field] = secondary_text
     end
     if not h.is_empty(config.image_field) then
-        if h.is_empty(config.image_attributes) then
-            ret[config.image_field] = string.format('<img src="%s">', snapshot_filename)
-        else
-            ret[config.image_field] = string.format('<img %s src="%s">', config.image_attributes, snapshot_filename)
-        end
+        ret[config.image_field] = string.format(config.image_template, snapshot_filename)
     end
     if not h.is_empty(config.audio_field) then
         ret[config.audio_field] = string.format('[sound:%s]', audio_filename)


### PR DESCRIPTION
A feature in Anki was added to have an image shrink in the editor if the `data-editor-shrink="true"` attribute is added to an image (see [here](https://github.com/ankitects/anki/commit/de2cc20c59a37e565976b297c48fa82c09ea5e62)). I added an option to allow the user to edit the image attribute directly, so if the user wants, they can have the image be shrunk by default.

I was thinking of making an option specifically for shrinking the image, i.e. something like `shrink_image = true`, but I decided against this for two reasons:
1. Anki might change how image resizing works, since the developers really like playing around with the UI. (In other words, we push the responsibility to the user editing the config, rather than the maintainers of this repo :wink:)
2. In the unusual case that more attributes are wanted by the user, this is general enough to support that.