### PR TITLE
Use the new option name for macOS detection

### DIFF
--- a/helpers.lua
+++ b/helpers.lua
@@ -51,7 +51,7 @@ this.is_win = function()
 end
 
 this.is_mac = function()
-    return mp.get_property('options/cocoa-force-dedicated-gpu') ~= nil
+    return mp.get_property('options/macos-force-dedicated-gpu') ~= nil
 end
 
 this.subprocess = function(args, completion_fn)


### PR DESCRIPTION
cocoa-force-dedicated-gpu was deprecated with this commit: https://github.com/mpv-player/mpv/commit/3275cd04b7531e3fb5528246eb04d40b8f2332e3

This fixes the deprecation warning on mpv startup.