### PR TITLE
Fixed secondary_sub_visibility=never not working

### DIFF
--- a/subtitles/secondary_sid.lua
+++ b/subtitles/secondary_sid.lua
@@ -91,6 +91,10 @@ local function on_file_loaded()
     end
 end
 
+local function update_visibility()
+    mp.set_property_bool('secondary-sub-visibility', self.visibility == 'always')
+end
+
 local function init(config)
     self.config = config
     self.visibility = config.secondary_sub_visibility
@@ -99,10 +103,7 @@ local function init(config)
     if config.secondary_sub_area > 0 then
         mp.observe_property('mouse-pos', 'native', on_mouse_move)
     end
-
-    if self.visibility ~= 'auto' then
-        mp.set_property_bool('secondary-sub-visibility', self.visibility == 'always')
-    end
+    update_visibility()
 end
 
 local function change_visibility()
@@ -112,9 +113,7 @@ local function change_visibility()
             break
         end
     end
-    if self.visibility ~= 'auto' then
-        mp.set_property_bool('secondary-sub-visibility', self.visibility == 'always')
-    end
+    update_visibility()
     h.notify("Secondary sid visibility: " .. self.visibility)
 end
 

--- a/subtitles/secondary_sid.lua
+++ b/subtitles/secondary_sid.lua
@@ -99,6 +99,10 @@ local function init(config)
     if config.secondary_sub_area > 0 then
         mp.observe_property('mouse-pos', 'native', on_mouse_move)
     end
+
+    if self.visibility ~= 'auto' then
+        mp.set_property_bool('secondary-sub-visibility', self.visibility == 'always')
+    end
 end
 
 local function change_visibility()


### PR DESCRIPTION
I attempted to use the following option in my config:
```
secondary_sub_visibility=never
```

It seems like the secondary subtitles still showed up until I used ctrl+v. This PR fixes that issue.

Notes:
- I didn't test it all too much, but I at least tested that ctrl+v still works with all three options in the config.
- I can't seem to find any uses for the `self.visibility ~= 'auto'` section (even in `change_visibility()` function), but I kept it just in case. In other words, everything seems to work perfectly fine even if the condition was removed.