### PR TITLE
Send files as base64-encoded data instead of sending the path

### DIFF
--- a/ankiconnect.lua
+++ b/ankiconnect.lua
@@ -8,6 +8,7 @@ AnkiConnect requests
 local utils = require('mp.utils')
 local msg = require('mp.msg')
 local h = require('helpers')
+local base64 = require('utils.base64')
 local self = {}
 
 self.execute = function(request, completion_fn)
@@ -48,12 +49,19 @@ self.parse_result = function(curl_output)
 end
 
 self.store_file = function(filename, file_path)
+    -- read the contents of the file and encode it in base64
+    -- this allows files to be stored even if Anki runs in a sandboxed environment
+    -- and thus doesn not have access to the host filesystem
+    local file = io.open(file_path, "rb")
+    local data = base64.enc(file:read("*a"))
+    file:close()
+
     local args = {
         action = "storeMediaFile",
         version = 6,
         params = {
             filename = filename,
-            path = file_path
+            data = data,
         }
     }
 

--- a/utils/base64.lua
+++ b/utils/base64.lua
@@ -1,0 +1,31 @@
+--[[
+Copyright: Ren Tatsumoto and contributors
+License: GNU GPL, version 3 or later; http://www.gnu.org/licenses/gpl.html
+
+Encoding and decoding in base64
+]]
+
+-- http://lua-users.org/wiki/BaseSixtyFour
+
+-- character table string
+local b = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+
+-- decoding
+local function dec(data)
+    data = string.gsub(data, '[^'..b..'=]', '')
+    return (data:gsub('.', function(x)
+        if (x == '=') then return '' end
+        local r,f='',(b:find(x)-1)
+        for i=6,1,-1 do r=r..(f%2^i-f%2^(i-1)>0 and '1' or '0') end
+        return r;
+    end):gsub('%d%d%d?%d?%d?%d?%d?%d?', function(x)
+        if (#x ~= 8) then return '' end
+        local c=0
+        for i=1,8 do c=c+(x:sub(i,i)=='1' and 2^(8-i) or 0) end
+        return string.char(c)
+    end))
+end
+
+return {
+    dec = dec,
+}

--- a/utils/base64.lua
+++ b/utils/base64.lua
@@ -10,6 +10,20 @@ Encoding and decoding in base64
 -- character table string
 local b = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
 
+-- encoding
+local function enc(data)
+    return ((data:gsub('.', function(x)
+        local r,b='',x:byte()
+        for i=8,1,-1 do r=r..(b%2^i-b%2^(i-1)>0 and '1' or '0') end
+        return r;
+    end)..'0000'):gsub('%d%d%d?%d?%d?%d?', function(x)
+        if (#x < 6) then return '' end
+        local c=0
+        for i=1,6 do c=c+(x:sub(i,i)=='1' and 2^(6-i) or 0) end
+        return b:sub(c+1,c+1)
+    end)..({ '', '==', '=' })[#data%3+1])
+end
+
 -- decoding
 local function dec(data)
     data = string.gsub(data, '[^'..b..'=]', '')
@@ -27,5 +41,6 @@ local function dec(data)
 end
 
 return {
+    enc = enc,
     dec = dec,
 }

--- a/utils/forvo.lua
+++ b/utils/forvo.lua
@@ -8,26 +8,8 @@ Utils for downloading pronunciations from Forvo
 local utils = require('mp.utils')
 local msg = require('mp.msg')
 local h = require('helpers')
+local base64 = require('utils.base64')
 local self = {}
-
-local base64d = (function()
-    -- http://lua-users.org/wiki/BaseSixtyFour
-    local b = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
-    return function(data)
-        data = string.gsub(data, '[^' .. b .. '=]', '')
-        return (data:gsub('.', function(x)
-            if (x == '=') then return '' end
-            local r, f = '', (b:find(x) - 1)
-            for i = 6, 1, -1 do r = r .. (f % 2 ^ i - f % 2 ^ (i - 1) > 0 and '1' or '0') end
-            return r;
-        end)        :gsub('%d%d%d?%d?%d?%d?%d?%d?', function(x)
-            if (#x ~= 8) then return '' end
-            local c = 0
-            for i = 1, 8 do c = c + (x:sub(i, i) == '1' and 2 ^ (8 - i) or 0) end
-            return string.char(c)
-        end))
-    end
-end)()
 
 local function url_encode(url)
     -- https://gist.github.com/liukun/f9ce7d6d14fa45fe9b924a3eed5c3d99
@@ -84,7 +66,7 @@ local function get_pronunciation_url(word)
     if play_params then
         local iter = string.gmatch(play_params, "'(.-)'")
         local formats = { mp3 = iter(), ogg = iter() }
-        return string.format('https://audio00.forvo.com/%s/%s', file_format, base64d(formats[file_format]))
+        return string.format('https://audio00.forvo.com/%s/%s', file_format, base64.dec(formats[file_format]))
     end
 end
 


### PR DESCRIPTION
### Description of changes
Change `ankiconnect.store_file` function to send audio files and screenshots in base64 instead of sending the path.

### Motivation
Currently, you cannot use mpvacious with Anki from Flatpak, because Flatpak does not allow access to the host's `/tmp` directory. As a workaround, you can use Flatseal or the command line to give Anki access to `/tmp`. Alternatively, simply send the files in JSON itself. Yomichan, for example, does the latter.