### PR TITLE
Output forvo audio files to anki media dir instead of calling store_file

### DIFF
--- a/subs2srs.lua
+++ b/subs2srs.lua
@@ -397,7 +397,8 @@ local function update_last_note(overwrite)
         return h.notify("Couldn't find the target note.", "warn", 2)
     end
 
-    encoder.set_output_dir(get_anki_media_dir_path())
+    local anki_media_dir = get_anki_media_dir_path()
+    encoder.set_output_dir(anki_media_dir)
     local snapshot = encoder.snapshot.create_job(sub)
     local audio = encoder.audio.create_job(sub, audio_padding())
 
@@ -409,6 +410,7 @@ local function update_last_note(overwrite)
     local new_data = construct_note_fields(sub['text'], sub['secondary'], snapshot.filename, audio.filename)
     local stored_data = ankiconnect.get_note_fields(last_note_id)
     if stored_data then
+        forvo.set_output_dir(anki_media_dir)
         new_data = forvo.append(new_data, stored_data)
         new_data = update_sentence(new_data, stored_data)
         if not overwrite then
@@ -546,7 +548,7 @@ local main = (function()
 
         cfg_mgr.init(config, profiles)
         ankiconnect.init(config, platform)
-        forvo.init(config, ankiconnect, platform)
+        forvo.init(config, platform)
         encoder.init(config)
         secondary_sid.init(config)
         ensure_deck()

--- a/utils/forvo.lua
+++ b/utils/forvo.lua
@@ -9,7 +9,9 @@ local utils = require('mp.utils')
 local msg = require('mp.msg')
 local h = require('helpers')
 local base64 = require('utils.base64')
-local self = {}
+local self = {
+    output_dir_path = nil,
+}
 
 local function url_encode(url)
     -- https://gist.github.com/liukun/f9ce7d6d14fa45fe9b924a3eed5c3d99
@@ -46,11 +48,9 @@ local function reencode(source_path, dest_path)
 end
 
 local function reencode_and_store(source_path, filename)
-    local reencoded_path = utils.join_path(self.platform.tmp_dir(), 'reencoded_' .. filename)
-    reencode(source_path, reencoded_path)
-    local result = self.ankiconnect.store_file(filename, reencoded_path)
-    os.remove(reencoded_path)
-    return result
+    local reencoded_path = utils.join_path(self.output_dir_path, filename)
+    local result = reencode(source_path, reencoded_path)
+    return result.status == 0
 end
 
 local function curl_save(source_url, save_location)
@@ -127,13 +127,17 @@ local append = function(new_data, stored_data)
     return new_data
 end
 
-local function init(config, ankiconnect, platform)
+local set_output_dir = function(dir_path)
+    self.output_dir_path = dir_path
+end
+
+local function init(config, platform)
     self.config = config
-    self.ankiconnect = ankiconnect
     self.platform = platform
 end
 
 return {
     append = append,
     init = init,
+    set_output_dir = set_output_dir,
 }


### PR DESCRIPTION
Currently, adding audio with forvo does not work because it tries to call `ankiconnect.store_file`, which was removed in a184107. This PR fixes the problem by outputting files directly to the Anki media directory instead.