### PR TITLE
Don't use hyphen in filename

### DIFF
--- a/utils/filename_factory.lua
+++ b/utils/filename_factory.lua
@@ -59,7 +59,7 @@ local function timestamp_range(start_timestamp, end_timestamp, extension)
     -- Generates a filename suffix of the form: _00h00m00s000ms-99h99m99s999ms.extension
     -- Extension must already contain the dot.
     return string.format(
-            '_%s-%s%s',
+            '_%s_%s%s',
             h.human_readable_time(start_timestamp),
             h.human_readable_time(end_timestamp),
             extension

--- a/utils/filename_factory.lua
+++ b/utils/filename_factory.lua
@@ -80,7 +80,7 @@ local make_filename = function(...)
     local args = {...}
     local timestamp = #args < 3 and timestamp_static(...) or timestamp_range(...)
     local filename_ = anki_compatible_length(filename, timestamp) .. timestamp
-    filename_ = filename_:lower()
+    filename_ = string.lower(filename_)
     return filename_
 end
 

--- a/utils/filename_factory.lua
+++ b/utils/filename_factory.lua
@@ -79,9 +79,7 @@ end
 local make_filename = function(...)
     local args = {...}
     local timestamp = #args < 3 and timestamp_static(...) or timestamp_range(...)
-    local filename_ = anki_compatible_length(filename, timestamp) .. timestamp
-    filename_ = string.lower(filename_)
-    return filename_
+    return string.lower(anki_compatible_length(filename, timestamp) .. timestamp)
 end
 
 mp.register_event("file-loaded", make_media_filename)

--- a/utils/filename_factory.lua
+++ b/utils/filename_factory.lua
@@ -79,7 +79,9 @@ end
 local make_filename = function(...)
     local args = {...}
     local timestamp = #args < 3 and timestamp_static(...) or timestamp_range(...)
-    return anki_compatible_length(filename, timestamp) .. timestamp
+    local filename_ = anki_compatible_length(filename, timestamp) .. timestamp
+    filename_ = filename_:lower()
+    return filename_
 end
 
 mp.register_event("file-loaded", make_media_filename)


### PR DESCRIPTION
Anki can't read filenames that include hyphens, https://stackoverflow.com/a/76066319. There is also a casing problem, I think. This happens randomly in Anki
![image](https://github.com/Ajatt-Tools/mpvacious/assets/25168308/29fa2368-bb11-4713-8000-7c1ea670f9bf)
