### PR TITLE
Simpler double quote replacement

### DIFF
--- a/platform/win.lua
+++ b/platform/win.lua
@@ -20,11 +20,7 @@ self.tmp_dir = function()
 end
 
 self.copy_to_clipboard = function(text)
-    text = text:gsub("&", "^^^&"):gsub("[<>|]", "")
-    local _, quote_count = text:gsub("\"", "")
-    if quote_count % 2 ~= 0 then
-        text = text:gsub("\"", "'")
-    end
+    text = text:gsub("&", "^^^&"):gsub("[<>|]", ""):gsub("\"", '“')
     mp.commandv("run", "cmd.exe", "/d", "/c", string.format("@echo off & chcp 65001 >nul & echo %s|clip", text))
 end
 
@@ -47,4 +43,3 @@ self.curl_request = function(url, request_json, completion_fn)
 end
 
 return self
-


### PR DESCRIPTION
What drove me to submit this PR was the fact that double quotes were still copied as `\"` which made for unappealing and distracting looking cards. 2 apostrophes in a row look very similar so it's still visually pleasing and avoids issues with escaping double quotes