### PR TITLE
Correctly set manual timings if audio offset != 0

### DIFF
--- a/subtitles/observer.lua
+++ b/subtitles/observer.lua
@@ -155,7 +155,7 @@ self.collect = function()
 end
 
 self.set_manual_timing = function(position)
-    user_timings.set(position, mp.get_property_number('time-pos'))
+    user_timings.set(position, mp.get_property_number('time-pos') - mp.get_property("audio-delay"))
     h.notify(h.capitalize_first_letter(position) .. " time has been set.")
     start_appending()
 end
@@ -163,7 +163,7 @@ end
 self.set_manual_timing_to_sub = function(position)
     local sub = Subtitle:now()
     if sub then
-        user_timings.set(position, sub[position])
+        user_timings.set(position, sub[position] - mp.get_property("audio-delay"))
         h.notify(h.capitalize_first_letter(position) .. " time has been set.")
         start_appending()
     else


### PR DESCRIPTION
This fixes a bug which is present if video and audio were downloaded from different sources and don't align perfectly. So, mpv's `add audio-delay` is used to align them.

In such a case, when cards are updated via `mpvacious-update-last-note` mpvacious works as expected. `subs_observer.set_to_current_sub` also works fine because it relies on the sub timing. But when setting timings manually (as with the functions involved in this PR), the audio delay is not taken into account. As such, audio on the final card is off by the value of the offset audio.

You can test this by adding an audio delay, opening the mpvacious menu and pressing `s` / `e` to set the timings manually, and `c` to use the current sub timing. Assuming you're at the beginning / end of the sub, these values should be the same.