### PR TITLE
Add ability to autocopy JSON

### DIFF
--- a/.github/RELEASE/subs2srs.conf
+++ b/.github/RELEASE/subs2srs.conf
@@ -71,13 +71,18 @@ allow_duplicates=no
 # This option can be also toggled in the addon's OSD menu.
 autoclip=no
 
-# Command to run when autoclip is triggered.
-# If empty, just copies text to the clipboard.
+# Possible options:
+# "disabled" - autocopy is disabled
+# "clipboard" - copy to the system clipboard (e.g. uses xclip)
+# "goldendict" - send the subtitle string to goldendict (goldendict-ng).
+# "clipboard_json" - copy json to the clipboard.
+# "custom_command" - run any custom command specified in `autoclip_command`.
+autoclip_method=clipboard
+
+# Command to run when autoclip is enabled and set to "custom_command".
+# If empty, nothing will be done.
 # If set, calls the external program.
-# E.g., even though GoldenDict can watch the system clipboard,
-# if you send subtitles directly to GoldenDict, you don't pollute the clipboard as much.
 autoclip_command=
-#autoclip_command=goldendict
 
 # Remove all spaces from the primary subtitle text.
 # Set this to "yes" for languages without spaces like Japanese.

--- a/.github/RELEASE/subs2srs.conf
+++ b/.github/RELEASE/subs2srs.conf
@@ -75,13 +75,15 @@ autoclip=no
 # "disabled" - autocopy is disabled
 # "clipboard" - copy to the system clipboard (e.g. uses xclip)
 # "goldendict" - send the subtitle string to goldendict (goldendict-ng).
-# "clipboard_json" - copy json to the clipboard.
 # "custom_command" - run any custom command specified in `autoclip_command`.
 autoclip_method=clipboard
 
 # Command to run when autoclip is enabled and set to "custom_command".
 # If empty, nothing will be done.
 # If set, calls the external program.
+# The following substitutions are supported:
+# %MPV_PRIMARY% - primary subtitle line
+# %MPV_SECONDARY% - secondary subtitle line
 autoclip_command=
 
 # Remove all spaces from the primary subtitle text.

--- a/subs2srs.lua
+++ b/subs2srs.lua
@@ -454,6 +454,7 @@ menu.keybindings = {
     { key = 'm', fn = menu:with_update { update_last_note, false } },
     { key = 'M', fn = menu:with_update { update_last_note, true } },
     { key = 't', fn = menu:with_update { subs_observer.toggle_autocopy } },
+    { key = 'T', fn = menu:with_update { subs_observer.toggle_autocopy_json } },
     { key = 'i', fn = menu:with_update { menu.hints_state.bump } },
     { key = 'p', fn = menu:with_update { load_next_profile } },
     { key = 'ESC', fn = function() menu:close() end },
@@ -491,6 +492,7 @@ function menu:print_bindings(osd)
         osd:tab():item('g: '):text('GUI export'):newline()
         osd:tab():item('m: '):text('Update the last added note '):italics('(+shift to overwrite)'):newline()
         osd:tab():item('t: '):text('Toggle clipboard autocopy'):newline()
+        osd:tab():item('T: '):text('Toggle clipboard autocopy as JSON'):newline()
         osd:tab():item('p: '):text('Switch to next profile'):newline()
         osd:tab():item('ESC: '):text('Close'):newline()
         osd:italics("Press "):item('i'):italics(" to show global bindings."):newline()
@@ -561,6 +563,7 @@ local main = (function()
         -- Key bindings
         mp.add_forced_key_binding("Ctrl+c", "mpvacious-copy-sub-to-clipboard", subs_observer.copy_current_to_clipboard)
         mp.add_key_binding("Ctrl+t", "mpvacious-autocopy-toggle", subs_observer.toggle_autocopy)
+        mp.add_key_binding("Ctrl+Shift+t", "mpvacious-autocopy-json-toggle", subs_observer.toggle_autocopy_json)
         mp.add_key_binding("Ctrl+g", "mpvacious-animated-snapshot-toggle", encoder.snapshot.toggle_animation)
 
         -- Secondary subtitles

--- a/subs2srs.lua
+++ b/subs2srs.lua
@@ -36,6 +36,8 @@ For complete usage guide, see <https://github.com/Ajatt-Tools/mpvacious/blob/mas
 ]]
 
 local config = {
+    -- The user should not modify anything below.
+
     -- Common
     nuke_spaces = false, -- remove all spaces from the primary subtitles on exported anki cards and when copying text to clipboard.
     clipboard_trim_enabled = true, -- remove unnecessary characters from strings before copying to the clipboard
@@ -44,7 +46,8 @@ local config = {
 
     -- Clipboard and external communication
     autoclip = false, -- enable copying subs to the clipboard when mpv starts
-    autoclip_command = "", -- command to run when autoclip is triggered. if empty, just copies sub_text to the clipboard.
+    autoclip_method = "clipboard", -- one of the methods
+    autoclip_command = "", -- command to run when autoclip is triggered and autoclip_method and set to "custom_command".
 
     -- Secondary subtitle
     secondary_sub_auto_load = true, -- Automatically load secondary subtitle track when a video file is opened.
@@ -454,7 +457,7 @@ menu.keybindings = {
     { key = 'm', fn = menu:with_update { update_last_note, false } },
     { key = 'M', fn = menu:with_update { update_last_note, true } },
     { key = 't', fn = menu:with_update { subs_observer.toggle_autocopy } },
-    { key = 'T', fn = menu:with_update { subs_observer.toggle_autocopy_json } },
+    { key = 'T', fn = menu:with_update { subs_observer.next_autoclip_method } },
     { key = 'i', fn = menu:with_update { menu.hints_state.bump } },
     { key = 'p', fn = menu:with_update { load_next_profile } },
     { key = 'ESC', fn = function() menu:close() end },
@@ -492,7 +495,7 @@ function menu:print_bindings(osd)
         osd:tab():item('g: '):text('GUI export'):newline()
         osd:tab():item('m: '):text('Update the last added note '):italics('(+shift to overwrite)'):newline()
         osd:tab():item('t: '):text('Toggle clipboard autocopy'):newline()
-        osd:tab():item('T: '):text('Toggle clipboard autocopy as JSON'):newline()
+        osd:tab():item('T: '):text('Switch to the next clipboard method'):newline()
         osd:tab():item('p: '):text('Switch to next profile'):newline()
         osd:tab():item('ESC: '):text('Close'):newline()
         osd:italics("Press "):item('i'):italics(" to show global bindings."):newline()
@@ -563,7 +566,6 @@ local main = (function()
         -- Key bindings
         mp.add_forced_key_binding("Ctrl+c", "mpvacious-copy-sub-to-clipboard", subs_observer.copy_current_to_clipboard)
         mp.add_key_binding("Ctrl+t", "mpvacious-autocopy-toggle", subs_observer.toggle_autocopy)
-        mp.add_key_binding("Ctrl+Shift+t", "mpvacious-autocopy-json-toggle", subs_observer.toggle_autocopy_json)
         mp.add_key_binding("Ctrl+g", "mpvacious-animated-snapshot-toggle", encoder.snapshot.toggle_animation)
 
         -- Secondary subtitles

--- a/utils/switch.lua
+++ b/utils/switch.lua
@@ -19,9 +19,17 @@ local make_switch = function(states)
     local get = function()
         return self.states[self.current_state]
     end
+    local set = function(new_state)
+        for idx, value in ipairs(self.states) do
+            if value == new_state then
+                self.current_state = idx
+            end
+        end
+    end
     return {
         bump = bump,
-        get = get
+        get = get,
+        set = set,
     }
 end
 


### PR DESCRIPTION
I have [an application I'm working on](https://github.com/udoprog/jpv) which can toggle the ability to process the clipboard content as JSON so that translations can be displayed alongside the text being analyzed.

I've also tried to modify the mime type where it is supported (e.g. `wl-copy --type application/json`) but this seems to largely be ignored in GNOME. It wouldn't hurt to set it though for future reference.

Tried to keep most things as-is and follow the style. But I don't work in Lua a lot so apologies if something is off.