### PR TITLE
Fix pattern matching for 'wl-clipboard' in is_wl_copy_installed function

### DIFF
--- a/platform/nix.lua
+++ b/platform/nix.lua
@@ -14,7 +14,7 @@ if h.is_mac() then
 elseif h.is_wayland() then
     local function is_wl_copy_installed()
         local handle = h.subprocess { 'wl-copy', '--version' }
-        return handle.status == 0 and handle.stdout:match("wl-clipboard") ~= nil
+        return handle.status == 0 and handle.stdout:match("wl%-clipboard") ~= nil
     end
 
     self.clip_util = "wl-copy"


### PR DESCRIPTION
The `is_wl_copy_installed` function fails to correctly match the "wl-clipboard' string due to a pattern matching error as a result of the hyphen character. This fix involves properly escaping the hyphen character in the pattern to ensure accurate matching and correctly detect wl-copy.