### PR TITLE
Encoder improvements

### DIFF
--- a/.github/RELEASE/subs2srs.conf
+++ b/.github/RELEASE/subs2srs.conf
@@ -148,9 +148,9 @@ snapshot_format=avif
 snapshot_quality=15
 
 # Image dimensions
-# If either (but not both) of the width or height parameters is -1,
+# If either (but not both) of the width or height parameters is -2,
 # the value will be calculated preserving the aspect-ratio.
-snapshot_width=-1
+snapshot_width=-2
 snapshot_height=200
 
 # Screenshot (yes, no)
@@ -190,9 +190,9 @@ animated_snapshot_format=avif
 animated_snapshot_fps=10
 
 # Animated snapshot dimensions
-# If either (but not both) of the width or height parameters is -1,
+# If either (but not both) of the width or height parameters is -2,
 # the value will be calculated preserving the aspect-ratio.
-animated_snapshot_width=-1
+animated_snapshot_width=-2
 animated_snapshot_height=200
 
 # Quality of the produced animation, 0 = lowest, 100 = highest

--- a/.github/RELEASE/subs2srs.conf
+++ b/.github/RELEASE/subs2srs.conf
@@ -208,12 +208,14 @@ animated_snapshot_quality=5
 audio_format=opus
 #audio_format=mp3
 
-# It may be required to use a different container for Opus, e.g. for AnkiMobile.
-# M4A (iOS 17.2 and probably even earlier) and WEBM (since iOS 17.4) play everywhere.
-# Ogg/Opus play everywhere except AnkiWeb in Safari and AnkiMobile.
-# Opus in CAF can be used with older iOS. CAF plays only on Anki Desktop, Safari and AnkiMobile.
-# (iOS Lockdown Mode disables Opus support completely,
-#  though you may try to add an exception for AnkiMobile.)
+# It may be required to use a different container for Opus.
+# This is the case on certain computers or devices
+# which are running proprietary operating systems, e.g. AnkiMobile. Using them is discouraged.
+# ・ Ogg/Opus play everywhere except AnkiWeb in Safari and AnkiMobile.
+# ・ M4A (iOS 17.2 and probably even earlier) and WEBM (since iOS 17.4) play everywhere.
+# ・ Opus in CAF can be used with older iOS. CAF plays only on Anki Desktop, Safari and AnkiMobile.
+# ・ (iOS Lockdown Mode disables Opus support completely,
+#    though you may try to add an exception for AnkiMobile.)
 opus_container=ogg
 #opus_container=opus
 #opus_container=m4a

--- a/.github/RELEASE/subs2srs.conf
+++ b/.github/RELEASE/subs2srs.conf
@@ -291,11 +291,12 @@ secondary_sub_area=0.15
 # Default binding to cycle this value: Ctrl+v.
 secondary_sub_visibility=auto
 
-# Perform loudness normalization.
+# Perform two-pass loudness normalization.
 # Parameter explanation can be found e.g. at:
 # https://auphonic.com/blog/2013/01/07/loudness-targets-mobile-audio-podcasts-radio-tv/
 # https://auphonic.com/blog/2019/08/19/dynamic-range-processing/
-loudnorm=yes
+# MAKE SURE TO REMOVE loudnorm FROM CUSTOM ARGS BEFORE ENABLING.
+loudnorm=no
 loudnorm_target=-16
 loudnorm_range=11
 loudnorm_peak=-1.5
@@ -307,9 +308,19 @@ loudnorm_peak=-1.5
 ## Feel free to experiment for yourself, but be careful or media creation might stop working.
 ##
 
+# loudnorm IN CUSTOM ARGS IS LEFT FOR BACKWARD COMPATIBILITY.
+# MAKE SURE TO REMOVE ALL MENTIONS OF loudnorm FROM CUSTOM ARGS
+# (E.G. SET TO EMPTY STRINGS) BEFORE ENABLING TWO-PASS loudnorm.
+# ENABLING loudnorm BOTH THROUGH THE SWITCH AND THROUGH CUSTOM ARGS
+# CAN LEAD TO UNPREDICTABLE RESULTS.
+
 # Ffmpeg
+ffmpeg_audio_args=-af loudnorm=I=-16:TP=-1.5:LRA=11:dual_mono=true
+#ffmpeg_audio_args=
 #ffmpeg_audio_args=-af silenceremove=1:0:-50dB
 
 # mpv
 # mpv accepts each filter as a separate argument, e.g. --af-append=1 --af-append=2
+mpv_audio_args=--af-append=loudnorm=I=-16:TP=-1.5:LRA=11:dual_mono=true
+#mpv_audio_args=
 #mpv_audio_args=--af-append=silenceremove=1:0:-50dB

--- a/.github/RELEASE/subs2srs.conf
+++ b/.github/RELEASE/subs2srs.conf
@@ -106,7 +106,7 @@ append_media=yes
 # Remove text in brackets before substituting %n into tag
 tag_nuke_brackets=yes
 
-# Remove text in brackets before substituting %n into tag
+# Remove text in parentheses before substituting %n into tag
 tag_nuke_parentheses=no
 
 # Remove the episode number before substituting %n into tag
@@ -148,9 +148,9 @@ snapshot_format=avif
 snapshot_quality=15
 
 # Image dimensions
-# If either (but not both) of the width or height parameters is -2,
+# If either (but not both) of the width or height parameters is -1,
 # the value will be calculated preserving the aspect-ratio.
-snapshot_width=-2
+snapshot_width=-1
 snapshot_height=200
 
 # Screenshot (yes, no)
@@ -182,14 +182,17 @@ audio_template=[sound:%s]
 # If enabled, generates animated snapshots (something like GIFs) instead of static snapshots.
 animated_snapshot_enabled=no
 
+animated_snapshot_format=avif
+#animated_snapshot_format=webp
+
 # Number of frame per seconds, a value between 0 and 30 (30 included)
 # Higher values will increase both quality and file size, lower values will do the opposite
 animated_snapshot_fps=10
 
 # Animated snapshot dimensions
-# If either (but not both) of the width or height parameters is -2,
+# If either (but not both) of the width or height parameters is -1,
 # the value will be calculated preserving the aspect-ratio.
-animated_snapshot_width=-2
+animated_snapshot_width=-1
 animated_snapshot_height=200
 
 # Quality of the produced animation, 0 = lowest, 100 = highest
@@ -201,11 +204,20 @@ animated_snapshot_quality=5
 
 # Audio format.
 # Opus is the recommended format.
-# It may be required to use a different format when Opus is not supported.
-# This is the case on certain computers or devices which are running proprietary operating systems.
 audio_format=opus
 #audio_format=mp3
-#audio_format=caf
+
+# It may be required to use a different container for Opus, e.g. for AnkiMobile.
+# M4A (iOS 17.2 and probably even earlier) and WEBM (since iOS 17.4) play everywhere.
+# Ogg/Opus play everywhere except AnkiWeb in Safari and AnkiMobile.
+# Opus in CAF can be used with older iOS. CAF plays only on Anki Desktop, Safari and AnkiMobile.
+# (iOS Lockdown Mode disables Opus support completely,
+#  though you may try to add an exception for AnkiMobile.)
+opus_container=ogg
+#opus_container=opus
+#opus_container=m4a
+#opus_container=webm
+#opus_container=caf
 
 # Sane values are 16k-32k for opus, 64k-128k for mp3.
 audio_bitrate=24k
@@ -275,6 +287,15 @@ secondary_sub_area=0.15
 # Default binding to cycle this value: Ctrl+v.
 secondary_sub_visibility=auto
 
+# Perform loudness normalization.
+# Parameter explanation can be found e.g. at:
+# https://auphonic.com/blog/2013/01/07/loudness-targets-mobile-audio-podcasts-radio-tv/
+# https://auphonic.com/blog/2019/08/19/dynamic-range-processing/
+loudnorm=yes
+loudnorm_target=-16
+loudnorm_range=11
+loudnorm_peak=-1.5
+
 ##
 ## Custom audio encoding arguments
 ## These arguments are added to the command line.
@@ -283,10 +304,8 @@ secondary_sub_visibility=auto
 ##
 
 # Ffmpeg
-ffmpeg_audio_args=-af loudnorm=I=-16:TP=-1.5:LRA=11
 #ffmpeg_audio_args=-af silenceremove=1:0:-50dB
 
 # mpv
 # mpv accepts each filter as a separate argument, e.g. --af-append=1 --af-append=2
-mpv_audio_args=--af-append=loudnorm=I=-16:TP=-1.5:LRA=11
 #mpv_audio_args=--af-append=silenceremove=1:0:-50dB

--- a/.github/RELEASE/subs2srs.conf
+++ b/.github/RELEASE/subs2srs.conf
@@ -208,6 +208,7 @@ animated_snapshot_quality=5
 audio_format=opus
 #audio_format=mp3
 
+# Container for opus files.
 # It may be required to use a different container for Opus.
 # This is the case on certain computers or devices
 # which are running proprietary operating systems, e.g. AnkiMobile. Using them is discouraged.

--- a/.github/RELEASE/subs2srs.conf
+++ b/.github/RELEASE/subs2srs.conf
@@ -182,6 +182,7 @@ audio_template=[sound:%s]
 # If enabled, generates animated snapshots (something like GIFs) instead of static snapshots.
 animated_snapshot_enabled=no
 
+# Animated snapshot format. Like "snapshot_format" but for animated images. Can be either avif or webp.
 animated_snapshot_format=avif
 #animated_snapshot_format=webp
 

--- a/README.md
+++ b/README.md
@@ -198,11 +198,12 @@ and `avif` or `webp` for images,
 as they greatly reduce the size of the generated files.
 
 If you still use AnkiMobile (the [proprietary](https://www.gnu.org/proprietary/) Anki app),
-set `audio_format` to [caf](https://en.wikipedia.org/wiki/Core_Audio_Format) for compatibility.
-The resulting files will use `Opus` as the coding format and Apple's Core Audio
-format as the container format, but will still have the `.ogg` extension to make
-it easier to open in media players because the `.caf` extension is not commonly
-recognized.
+set `opus_container` to `m4a` or `webm`. I'll allow iOS to play Opus files, while still maintaining
+compatibility with non-Apple devices. For really old iOS devices, set `opus_container` to
+[`caf`](https://en.wikipedia.org/wiki/Core_Audio_Format). CAF plays only on Anki Desktop,
+AnkiWeb in Safari and AnkiMobile, and is really not recommended. (Please note that
+[Lockdown Mode](https://support.apple.com/en-us/105120) completely disables Opus and AVIF support,
+though you may try to add an exception for AnkiMobile.)
 
 If no matter what mpvacious fails to create audio clips and/or snapshots,
 change `use_ffmpeg` to `yes`.

--- a/cfg_mgr.lua
+++ b/cfg_mgr.lua
@@ -196,4 +196,6 @@ return {
     reload_from_disk = reload_from_disk,
     init = init,
     next_profile = next_profile,
+    default_height_px = default_height_px,
+    preserve_aspect_ratio = preserve_aspect_ratio,
 }

--- a/cfg_mgr.lua
+++ b/cfg_mgr.lua
@@ -63,6 +63,8 @@ local function set_video_format()
         self.config.snapshot_codec = 'mjpeg'
     end
 
+    -- Animated webp images can only have .webp extension.
+    -- The user has no choice on this. Same logic for avif.
     if self.config.animated_snapshot_format == 'avif' then
         self.config.animated_snapshot_extension = '.avif'
         self.config.animated_snapshot_codec = 'libaom-av1'

--- a/encoder.lua
+++ b/encoder.lua
@@ -67,9 +67,13 @@ local function toms(timestamp)
     return string.format("%.3f", timestamp)
 end
 
-local function quality_to_crf(quality, max_crf)
-    -- Quality is from 0 to 100. (for avif images) CRF is from 0 to 63 and reversed.
-    return math.floor((100 - quality) / 100 * max_crf)
+local function rescale_quality(quality, min_q, max_q)
+    local scaled = min_q + (max_q - min_q) * quality / 100
+    -- Round to the nearest integer that's better in quality.
+    if min_q > max_q then
+        return math.floor(scaled)
+    end
+    return math.ceil(scaled)
 end
 
 ------------------------------------------------------------
@@ -77,42 +81,54 @@ end
 
 local ffmpeg = {}
 
-ffmpeg.prefix = { find_exec("ffmpeg"), "-hide_banner", "-nostdin", "-y", "-loglevel", "quiet", "-sn", }
+ffmpeg.exec = find_exec("ffmpeg")
 
-ffmpeg.prepend = function(args)
-    if next(args) ~= nil then
-        for i, value in ipairs(ffmpeg.prefix) do
-            table.insert(args, i, value)
-        end
-    end
-    return args
+ffmpeg.prepend = function(...)
+    return {
+        ffmpeg.exec, "-hide_banner", "-nostdin", "-y", "-loglevel", "quiet", "-sn",
+        ...,
+    }
 end
 
 ffmpeg.make_static_snapshot_args = function(source_path, output_path, timestamp)
-    local args = ffmpeg.prepend {
+    local encoder_args
+    if self.config.snapshot_format == 'avif' then
+        encoder_args = {
+            '-c:v', 'libaom-av1',
+            '-cpu-used', '6', -- cpu-used < 6 can take a lot of time to encode.
+            '-crf', tostring(rescale_quality(self.config.snapshot_quality, self.max_avif_crf, 0)),
+            '-still-picture', '1',
+        }
+    elseif self.config.snapshot_format == 'webp' then
+        encoder_args = {
+            '-c:v', 'libwebp',
+            '-compression_level', '6',
+            '-quality', tostring(self.config.snapshot_quality),
+        }
+    else
+        encoder_args = {
+            '-c:v', 'mjpeg',
+            '-q:v', tostring(rescale_quality(self.config.snapshot_quality, 31, 2)),
+        }
+    end
+
+    local args = ffmpeg.prepend(
         '-an',
         '-ss', toms(timestamp),
         '-i', source_path,
         '-map_metadata', '-1',
-        '-vcodec', self.config.snapshot_codec,
-        '-lossless', '0',
-        '-compression_level', '6',
-        '-qscale:v', tostring(self.config.snapshot_quality),
-        '-vf', string.format('scale=%d:%d', self.config.snapshot_width, self.config.snapshot_height),
-        '-vframes', '1',
-        output_path
-    }
-    if self.config.snapshot_format == 'avif' then
-        -- Avif quality can be controlled with crf.
-        table.insert(args, #args, '-crf')
-        table.insert(args, #args, tostring(quality_to_crf(self.config.snapshot_quality, self.max_avif_crf)))
-    end
+        '-vf', string.format("scale='min(%d,iw)':'min(%d,ih)':flags=sinc+accurate_rnd",
+                             self.config.snapshot_width, self.config.snapshot_height),
+        '-frames:v', '1',
+        table.unpack(encoder_args)
+    )
+    table.insert(args, output_path)
     return args
 end
 
 ffmpeg.animated_snapshot_filters = function()
     return string.format(
-            "fps=%d,scale=%d:%d:flags=lanczos",
+            "fps=%d,scale='min(%d,iw)':'min(%d,ih)':flags=lanczos+accurate_rnd",
             self.config.animated_snapshot_fps,
             self.config.animated_snapshot_width,
             self.config.animated_snapshot_height
@@ -120,21 +136,83 @@ ffmpeg.animated_snapshot_filters = function()
 end
 
 ffmpeg.make_animated_snapshot_args = function(source_path, output_path, start_timestamp, end_timestamp)
-    -- Documentation: https://www.ffmpeg.org/ffmpeg-all.html#libwebp
-    return ffmpeg.prepend {
+    local encoder_args
+    if self.config.animated_snapshot_format == 'avif' then
+        encoder_args = {
+            '-c:v', 'libaom-av1',
+            '-cpu-used', '6', -- cpu-used < 6 can take a lot of time to encode.
+            '-crf', tostring(rescale_quality(self.config.animated_snapshot_quality,
+                                             self.max_avif_crf, 0)),
+        }
+    else
+        -- Documentation: https://www.ffmpeg.org/ffmpeg-all.html#libwebp
+        encoder_args = {
+            '-c:v', 'libwebp',
+            '-compression_level', '6',
+            '-quality', tostring(self.config.animated_snapshot_quality),
+        }
+    end
+
+    local args = ffmpeg.prepend(
         '-an',
         '-ss', toms(start_timestamp),
-        '-t', toms(end_timestamp - start_timestamp),
+        '-to', toms(end_timestamp),
         '-i', source_path,
         '-map_metadata', '-1',
-        '-vcodec', 'libwebp',
         '-loop', '0',
-        '-lossless', '0',
-        '-compression_level', '6',
-        '-quality', tostring(self.config.animated_snapshot_quality),
         '-vf', ffmpeg.animated_snapshot_filters(),
-        output_path
-    }
+        table.unpack(encoder_args)
+    )
+    table.insert(args, output_path)
+    return args
+end
+
+local function make_loudnorm_targets()
+    return string.format(
+        'loudnorm=I=%s:LRA=%s:TP=%s:dual_mono=true',
+        self.config.loudnorm_target,
+        self.config.loudnorm_range,
+        self.config.loudnorm_peak
+    )
+end
+
+local function parse_loudnorm(loudnorm_targets, json_extractor, loudnorm_consumer)
+    local function warn()
+        msg.warn('Failed to measure loudnorm stats, falling back on dynamic loudnorm.')
+    end
+
+    return function(success, result)
+        local json
+        if success and result.status == 0 then
+            json = json_extractor(result.stdout, result.stderr)
+        end
+
+        if json == nil then
+            warn()
+            loudnorm_consumer(loudnorm_targets)
+            return
+        end
+
+        local loudnorm_args = { loudnorm_targets }
+        local function add_arg(name, val)
+            -- loudnorm sometimes fails to gather stats for extremely short inputs.
+            -- Simply omit the stat to fall back on dynamic loudnorm.
+            if val ~= '-inf' and val ~= 'inf' then
+                table.insert(loudnorm_args, string.format('%s=%s', name, val))
+            else
+                warn()
+            end
+        end
+
+        local stats = utils.parse_json(json)
+        add_arg('measured_I', stats.input_i)
+        add_arg('measured_LRA', stats.input_lra)
+        add_arg('measured_TP', stats.input_tp)
+        add_arg('measured_thresh', stats.input_thresh)
+        add_arg('offset', stats.target_offset)
+
+        loudnorm_consumer(table.concat(loudnorm_args, ':'))
+    end
 end
 
 ffmpeg.append_user_audio_args = function(args)
@@ -148,17 +226,18 @@ ffmpeg.append_user_audio_args = function(args)
         if arg == '-af' or arg == '-filter:a' then
             filters = #filters > 0 and string.format("%s,%s", args_iter(), filters) or args_iter()
         else
-            table.insert(args, #args, arg)
+            table.insert(args, arg)
         end
     end
     if #filters > 0 then
-        table.insert(args, #args, '-af')
-        table.insert(args, #args, filters)
+        table.insert(args, '-af')
+        table.insert(args, filters)
     end
     return args
 end
 
-ffmpeg.make_audio_args = function(source_path, output_path, start_timestamp, end_timestamp)
+ffmpeg.make_audio_args = function(source_path, output_path,
+                                  start_timestamp, end_timestamp, args_consumer)
     local audio_track = h.get_active_track('audio')
     local audio_track_id = audio_track['ff-index']
 
@@ -167,23 +246,76 @@ ffmpeg.make_audio_args = function(source_path, output_path, start_timestamp, end
         audio_track_id = 'a'
     end
 
-    local args = ffmpeg.prepend {
-        '-vn',
-        '-ss', toms(start_timestamp),
-        '-to', toms(end_timestamp),
-        '-i', source_path,
-        '-map_metadata', '-1',
-        '-map', string.format("0:%s", tostring(audio_track_id)),
-        '-ac', '1',
-        '-codec:a', self.config.audio_codec,
-        '-f', self.config.audio_format,
-        '-vbr', 'on',
-        '-compression_level', '10',
-        '-application', 'voip',
-        '-b:a', tostring(self.config.audio_bitrate),
-        output_path
-    }
-    return ffmpeg.append_user_audio_args(args)
+    local function make_ffargs(...)
+        return ffmpeg.append_user_audio_args(
+            ffmpeg.prepend(
+                '-vn',
+                '-ss', toms(start_timestamp),
+                '-to', toms(end_timestamp),
+                '-i', source_path,
+                '-map_metadata', '-1',
+                '-map_chapters', '-1',
+                '-map', string.format("0:%s", tostring(audio_track_id)),
+                '-ac', '1',
+                ...
+            )
+        )
+    end
+
+    local function make_encoding_args(loudnorm_args)
+        local encoder_args
+        if self.config.audio_format == 'opus' then
+            encoder_args = {
+                '-c:a', 'libopus',
+                '-application', 'voip',
+                '-apply_phase_inv', '0', -- Improves mono audio.
+            }
+            if self.config.opus_container == 'm4a' then
+                table.insert(encoder_args, '-f')
+                table.insert(encoder_args, 'mp4')
+            end
+        else
+            -- https://wiki.hydrogenaud.io/index.php?title=LAME#Recommended_encoder_settings:
+            -- "For very low bitrates, up to 100kbps, ABR is most often the best solution."
+            encoder_args = {
+                '-c:a', 'libmp3lame',
+                '-compression_level', '0',
+                '-abr', '1',
+            }
+        end
+
+        local args = make_ffargs('-b:a', tostring(self.config.audio_bitrate),
+                                 table.unpack(encoder_args))
+        if loudnorm_args then
+            table.insert(args, '-af')
+            table.insert(args, loudnorm_args)
+        end
+        table.insert(args, output_path)
+        args_consumer(args)
+    end
+
+    if not self.config.loudnorm then
+        make_encoding_args(nil)
+        return
+    end
+
+    local loudnorm_targets = make_loudnorm_targets()
+    h.subprocess(
+        make_ffargs(
+            '-loglevel', 'info',
+            '-af', loudnorm_targets .. ':print_format=json',
+            '-f', 'null',
+            '-'
+        ),
+        parse_loudnorm(
+            loudnorm_targets,
+            function(stdout, stderr)
+                local start, stop, json = string.find(stderr, '%[Parsed_loudnorm_0.-({.-})')
+                return json
+            end,
+            make_encoding_args
+        )
+    )
 end
 
 ------------------------------------------------------------
@@ -193,55 +325,91 @@ local mpv = { }
 
 mpv.exec = find_exec("mpv")
 
-mpv.make_static_snapshot_args = function(source_path, output_path, timestamp)
-    local args = {
-        mpv.exec,
-        source_path,
-        '--loop-file=no',
-        '--keep-open=no',
-        '--audio=no',
-        '--no-ocopy-metadata',
-        '--no-sub',
-        '--frames=1',
-        '--ovcopts-add=lossless=0',
-        '--ovcopts-add=compression_level=6',
-        table.concat { '--ovc=', self.config.snapshot_codec },
-        table.concat { '-start=', toms(timestamp), },
-        table.concat { '--ovcopts-add=quality=', tostring(self.config.snapshot_quality) },
-        table.concat { '--vf-add=scale=', self.config.snapshot_width, ':', self.config.snapshot_height },
-        table.concat { '-o=', output_path }
-    }
-    if self.config.snapshot_format == 'avif' then
-        -- Avif quality can be controlled with crf.
-        table.insert(args, #args, string.format('--ovcopts-add=crf=%d', quality_to_crf(self.config.snapshot_quality, self.max_avif_crf)))
-    end
-    return args
-end
-
-mpv.make_animated_snapshot_args = function(source_path, output_path, start_timestamp, end_timestamp)
+mpv.prepend_common_args = function(source_path, ...)
     return {
         mpv.exec,
         source_path,
+        '--no-config',
         '--loop-file=no',
         '--keep-open=no',
-        '--ovc=libwebp',
-        '--of=webp',
-        '--ofopts-add=loop=0',
-        '--audio=no',
         '--no-sub',
         '--no-ocopy-metadata',
-        '--ovcopts-add=lossless=0',
-        '--ovcopts-add=compression_level=6',
-        table.concat { '--start=', toms(start_timestamp), },
-        table.concat { '--end=', toms(end_timestamp), },
-        table.concat { '--ovcopts-add=quality=', tostring(self.config.animated_snapshot_quality) },
-        table.concat { '--vf-add=scale=', self.config.animated_snapshot_width, ':', self.config.animated_snapshot_height, ':flags=lanczos', },
-        table.concat { '--vf-add=fps=', self.config.animated_snapshot_fps, },
-        table.concat { '-o=', output_path },
+        ...,
     }
 end
 
-mpv.make_audio_args = function(source_path, output_path, start_timestamp, end_timestamp)
+mpv.make_static_snapshot_args = function(source_path, output_path, timestamp)
+    local encoder_args
+    if self.config.snapshot_format == 'avif' then
+        encoder_args = {
+            '--ovc=libaom-av1',
+            '--ovcopts-add=cpu-used=6', -- cpu-used < 6 can take a lot of time to encode.
+            string.format('--ovcopts-add=crf=%d',
+                          rescale_quality(self.config.snapshot_quality, self.max_avif_crf, 0)),
+            '--ovcopts-add=still-picture=1',
+        }
+    elseif self.config.snapshot_format == 'webp' then
+        encoder_args = {
+            '--ovc=libwebp',
+            '--ovcopts-add=compression_level=6',
+            string.format('--ovcopts-add=quality=%d', self.config.snapshot_quality),
+        }
+    else
+        encoder_args = {
+            '--ovc=mjpeg',
+            '--vf-add=scale=out_range=jpeg',
+            string.format('--ovcopts=global_quality=%d*QP2LAMBDA,flags=+qscale',
+                          rescale_quality(self.config.snapshot_quality, 31, 2)),
+        }
+    end
+
+    return mpv.prepend_common_args(
+        source_path,
+        '--audio=no',
+        '--frames=1',
+        '--start=' .. toms(timestamp),
+        string.format("--vf-add=lavfi=[scale='min(%d,iw)':'min(%d,ih)':flags=sinc+accurate_rnd]",
+                      self.config.snapshot_width, self.config.snapshot_height),
+        '-o=' .. output_path,
+        table.unpack(encoder_args)
+    )
+end
+
+mpv.make_animated_snapshot_args = function(source_path, output_path, start_timestamp, end_timestamp)
+    local encoder_args
+    if self.config.animated_snapshot_format == 'avif' then
+        encoder_args = {
+            '--ovc=libaom-av1',
+            '--ovcopts-add=cpu-used=6', -- cpu-used < 6 can take a lot of time to encode.
+            string.format('--ovcopts-add=crf=%d',
+                          rescale_quality(self.config.snapshot_quality, self.max_avif_crf, 0)),
+        }
+    else
+        encoder_args = {
+            '--ovc=libwebp',
+            '--ovcopts-add=compression_level=6',
+            string.format('--ovcopts-add=quality=%d', self.config.snapshot_quality),
+        }
+    end
+
+    return mpv.prepend_common_args(
+        source_path,
+        '--audio=no',
+        '--start=' .. toms(start_timestamp),
+        '--end=' .. toms(end_timestamp),
+        '--ofopts-add=loop=0',
+        string.format('--vf-add=fps=%d', self.config.animated_snapshot_fps),
+        string.format(
+            "--vf-add=lavfi=[scale='min(%d,iw)':'min(%d,ih)':flags=lanczos+accurate_rnd]",
+            self.config.animated_snapshot_width, self.config.animated_snapshot_height
+        ),
+        '-o=' .. output_path,
+        table.unpack(encoder_args)
+    )
+end
+
+mpv.make_audio_args = function(source_path, output_path,
+                               start_timestamp, end_timestamp, args_consumer)
     local audio_track = h.get_active_track('audio')
     local audio_track_id = mp.get_property("aid")
 
@@ -250,31 +418,83 @@ mpv.make_audio_args = function(source_path, output_path, start_timestamp, end_ti
         audio_track_id = 'auto'
     end
 
-    local args = {
-        mpv.exec,
-        source_path,
-        '--loop-file=no',
-        '--video=no',
-        '--no-ocopy-metadata',
-        '--no-sub',
-        '--audio-channels=mono',
-        '--oacopts-add=vbr=on',
-        '--oacopts-add=application=voip',
-        '--oacopts-add=compression_level=10',
-        table.concat { '--oac=', self.config.audio_codec },
-        table.concat { '--of=', self.config.audio_format },
-        table.concat { '--start=', toms(start_timestamp), },
-        table.concat { '--end=', toms(end_timestamp), },
-        table.concat { '--aid=', audio_track_id },
-        table.concat { '--volume=', self.config.tie_volumes and mp.get_property('volume') or '100' },
-        table.concat { '--oacopts-add=b=', self.config.audio_bitrate },
-        table.concat { '-o=', output_path }
-    }
-    for arg in string.gmatch(self.config.mpv_audio_args, "%S+") do
-        -- Prepend before output path
-        table.insert(args, #args, arg)
+    local function make_mpvargs(...)
+        local args = mpv.prepend_common_args(
+            source_path,
+            '--video=no',
+            '--aid=' .. audio_track_id,
+            '--audio-channels=mono',
+            '--start=' .. toms(start_timestamp),
+            '--end=' .. toms(end_timestamp),
+            string.format(
+                '--volume=%d',
+                self.config.tie_volumes and mp.get_property('volume') or 100
+            ),
+            ...
+        )
+        for arg in string.gmatch(self.config.mpv_audio_args, "%S+") do
+            table.insert(args, arg)
+        end
+        return args
     end
-    return args
+
+    local function make_encoding_args(loudnorm_args)
+        local encoder_args
+        if self.config.audio_format == 'opus' then
+            encoder_args = {
+                '--oac=libopus',
+                '--oacopts-add=application=voip',
+                '--oacopts-add=apply_phase_inv=0', -- Improves mono audio.
+            }
+            if self.config.opus_container == 'm4a' then
+                table.insert(encoder_args, '--of=mp4')
+            end
+        else
+            -- https://wiki.hydrogenaud.io/index.php?title=LAME#Recommended_encoder_settings:
+            -- "For very low bitrates, up to 100kbps, ABR is most often the best solution."
+            encoder_args = {
+                '--oac=libmp3lame',
+                '--oacopts-add=compression_level=0',
+                '--oacopts-add=abr=1',
+            }
+        end
+
+        local args = make_mpvargs(
+            '--oacopts-add=b=' .. self.config.audio_bitrate,
+            '-o=' .. output_path,
+            table.unpack(encoder_args)
+        )
+        if loudnorm_args then
+            table.insert(args, '--af-append=' .. loudnorm_args)
+        end
+        args_consumer(args)
+    end
+
+    if not self.config.loudnorm then
+        make_encoding_args(nil)
+        return
+    end
+
+    local loudnorm_targets = make_loudnorm_targets()
+    h.subprocess(
+        make_mpvargs(
+            '-v',
+            '--af-append=' .. loudnorm_targets .. ':print_format=json',
+            '--ao=null',
+            '--of=null'
+        ),
+        parse_loudnorm(
+            loudnorm_targets,
+            function(stdout, stderr)
+                local start, stop, json = string.find(stdout, '%[ffmpeg%] ({.-})')
+                if json then
+                    json = string.gsub(json, '%[ffmpeg%]', '')
+                end
+                return json
+            end,
+            make_encoding_args
+        )
+    )
 end
 
 ------------------------------------------------------------
@@ -299,12 +519,15 @@ local create_static_snapshot = function(timestamp, source_path, output_path, on_
 end
 
 local report_creation_result = function(file_path)
-    if h.file_exists(file_path) then
-        msg.info(string.format("Created file: %s", file_path))
-        return true
-    else
-        msg.error(string.format("Couldn't create file: %s", file_path))
-        return false
+    return function(success, result)
+        -- result is nil on success for screenshot-to-file.
+        if success and (result == nil or result.status == 0) and h.file_exists(file_path) then
+            msg.info(string.format("Created file: %s", file_path))
+            return true
+        else
+            msg.error(string.format("Couldn't create file: %s", file_path))
+            return false
+        end
     end
 end
 
@@ -318,10 +541,7 @@ local create_snapshot = function(start_timestamp, end_timestamp, current_timesta
         local source_path = mp.get_property("path")
         local output_path = utils.join_path(self.output_dir_path, filename)
 
-        local on_finish = function()
-            report_creation_result(output_path)
-        end
-
+        local on_finish = report_creation_result(output_path)
         if self.config.animated_snapshot_enabled then
             create_animated_snapshot(start_timestamp, end_timestamp, source_path, output_path, on_finish)
         else
@@ -352,15 +572,21 @@ local create_audio = function(start_timestamp, end_timestamp, filename, padding)
             start_timestamp, end_timestamp = pad_timings(padding, start_timestamp, end_timestamp)
         end
 
-        local args = self.encoder.make_audio_args(source_path, output_path, start_timestamp, end_timestamp)
-        local on_finish = function()
-            if report_creation_result(output_path) and self.config.preview_audio then
-                background_play(output_path, function()
-                    print("Played file: " .. output_path)
-                end)
+        local function start_encoding(args)
+            local on_finish = function(success, result)
+                local conversion_check = report_creation_result(output_path)
+                if conversion_check(success, result) and self.config.preview_audio then
+                    background_play(output_path, function()
+                        print("Played file: " .. output_path)
+                    end)
+                end
             end
+
+            h.subprocess(args, on_finish)
         end
-        h.subprocess(args, on_finish)
+
+        self.encoder.make_audio_args(
+            source_path, output_path, start_timestamp, end_timestamp, start_encoding)
     else
         print("Audio will not be created.")
     end

--- a/encoder.lua
+++ b/encoder.lua
@@ -113,14 +113,14 @@ ffmpeg.make_static_snapshot_args = function(source_path, output_path, timestamp)
     end
 
     local args = ffmpeg.prepend(
-        '-an',
-        '-ss', toms(timestamp),
-        '-i', source_path,
-        '-map_metadata', '-1',
-        '-vf', string.format("scale='min(%d,iw)':'min(%d,ih)':flags=sinc+accurate_rnd",
-                             self.config.snapshot_width, self.config.snapshot_height),
-        '-frames:v', '1',
-        table.unpack(encoder_args)
+            '-an',
+            '-ss', toms(timestamp),
+            '-i', source_path,
+            '-map_metadata', '-1',
+            '-vf', string.format("scale='min(%d,iw)':'min(%d,ih)':flags=sinc+accurate_rnd",
+                    self.config.snapshot_width, self.config.snapshot_height),
+            '-frames:v', '1',
+            h.unpack(encoder_args)
     )
     table.insert(args, output_path)
     return args
@@ -142,7 +142,7 @@ ffmpeg.make_animated_snapshot_args = function(source_path, output_path, start_ti
             '-c:v', 'libaom-av1',
             '-cpu-used', '6', -- cpu-used < 6 can take a lot of time to encode.
             '-crf', tostring(rescale_quality(self.config.animated_snapshot_quality,
-                                             self.max_avif_crf, 0)),
+                    self.max_avif_crf, 0)),
         }
     else
         -- Documentation: https://www.ffmpeg.org/ffmpeg-all.html#libwebp
@@ -154,14 +154,14 @@ ffmpeg.make_animated_snapshot_args = function(source_path, output_path, start_ti
     end
 
     local args = ffmpeg.prepend(
-        '-an',
-        '-ss', toms(start_timestamp),
-        '-to', toms(end_timestamp),
-        '-i', source_path,
-        '-map_metadata', '-1',
-        '-loop', '0',
-        '-vf', ffmpeg.animated_snapshot_filters(),
-        table.unpack(encoder_args)
+            '-an',
+            '-ss', toms(start_timestamp),
+            '-to', toms(end_timestamp),
+            '-i', source_path,
+            '-map_metadata', '-1',
+            '-loop', '0',
+            '-vf', ffmpeg.animated_snapshot_filters(),
+            h.unpack(encoder_args)
     )
     table.insert(args, output_path)
     return args
@@ -169,10 +169,10 @@ end
 
 local function make_loudnorm_targets()
     return string.format(
-        'loudnorm=I=%s:LRA=%s:TP=%s:dual_mono=true',
-        self.config.loudnorm_target,
-        self.config.loudnorm_range,
-        self.config.loudnorm_peak
+            'loudnorm=I=%s:LRA=%s:TP=%s:dual_mono=true',
+            self.config.loudnorm_target,
+            self.config.loudnorm_range,
+            self.config.loudnorm_peak
     )
 end
 
@@ -248,17 +248,17 @@ ffmpeg.make_audio_args = function(source_path, output_path,
 
     local function make_ffargs(...)
         return ffmpeg.append_user_audio_args(
-            ffmpeg.prepend(
-                '-vn',
-                '-ss', toms(start_timestamp),
-                '-to', toms(end_timestamp),
-                '-i', source_path,
-                '-map_metadata', '-1',
-                '-map_chapters', '-1',
-                '-map', string.format("0:%s", tostring(audio_track_id)),
-                '-ac', '1',
-                ...
-            )
+                ffmpeg.prepend(
+                        '-vn',
+                        '-ss', toms(start_timestamp),
+                        '-to', toms(end_timestamp),
+                        '-i', source_path,
+                        '-map_metadata', '-1',
+                        '-map_chapters', '-1',
+                        '-map', string.format("0:%s", tostring(audio_track_id)),
+                        '-ac', '1',
+                        ...
+                )
         )
     end
 
@@ -284,8 +284,7 @@ ffmpeg.make_audio_args = function(source_path, output_path,
             }
         end
 
-        local args = make_ffargs('-b:a', tostring(self.config.audio_bitrate),
-                                 table.unpack(encoder_args))
+        local args = make_ffargs('-b:a', tostring(self.config.audio_bitrate), h.unpack(encoder_args))
         if loudnorm_args then
             table.insert(args, '-af')
             table.insert(args, loudnorm_args)
@@ -301,20 +300,20 @@ ffmpeg.make_audio_args = function(source_path, output_path,
 
     local loudnorm_targets = make_loudnorm_targets()
     h.subprocess(
-        make_ffargs(
-            '-loglevel', 'info',
-            '-af', loudnorm_targets .. ':print_format=json',
-            '-f', 'null',
-            '-'
-        ),
-        parse_loudnorm(
-            loudnorm_targets,
-            function(stdout, stderr)
-                local start, stop, json = string.find(stderr, '%[Parsed_loudnorm_0.-({.-})')
-                return json
-            end,
-            make_encoding_args
-        )
+            make_ffargs(
+                    '-loglevel', 'info',
+                    '-af', loudnorm_targets .. ':print_format=json',
+                    '-f', 'null',
+                    '-'
+            ),
+            parse_loudnorm(
+                    loudnorm_targets,
+                    function(stdout, stderr)
+                        local start, stop, json = string.find(stderr, '%[Parsed_loudnorm_0.-({.-})')
+                        return json
+                    end,
+                    make_encoding_args
+            )
     )
 end
 
@@ -344,8 +343,10 @@ mpv.make_static_snapshot_args = function(source_path, output_path, timestamp)
         encoder_args = {
             '--ovc=libaom-av1',
             '--ovcopts-add=cpu-used=6', -- cpu-used < 6 can take a lot of time to encode.
-            string.format('--ovcopts-add=crf=%d',
-                          rescale_quality(self.config.snapshot_quality, self.max_avif_crf, 0)),
+            string.format(
+                    '--ovcopts-add=crf=%d',
+                    rescale_quality(self.config.snapshot_quality, self.max_avif_crf, 0)
+            ),
             '--ovcopts-add=still-picture=1',
         }
     elseif self.config.snapshot_format == 'webp' then
@@ -358,20 +359,24 @@ mpv.make_static_snapshot_args = function(source_path, output_path, timestamp)
         encoder_args = {
             '--ovc=mjpeg',
             '--vf-add=scale=out_range=jpeg',
-            string.format('--ovcopts=global_quality=%d*QP2LAMBDA,flags=+qscale',
-                          rescale_quality(self.config.snapshot_quality, 31, 2)),
+            string.format(
+                    '--ovcopts=global_quality=%d*QP2LAMBDA,flags=+qscale',
+                    rescale_quality(self.config.snapshot_quality, 31, 2)
+            ),
         }
     end
 
     return mpv.prepend_common_args(
-        source_path,
-        '--audio=no',
-        '--frames=1',
-        '--start=' .. toms(timestamp),
-        string.format("--vf-add=lavfi=[scale='min(%d,iw)':'min(%d,ih)':flags=sinc+accurate_rnd]",
-                      self.config.snapshot_width, self.config.snapshot_height),
-        '-o=' .. output_path,
-        table.unpack(encoder_args)
+            source_path,
+            '--audio=no',
+            '--frames=1',
+            '--start=' .. toms(timestamp),
+            string.format(
+                    "--vf-add=lavfi=[scale='min(%d,iw)':'min(%d,ih)':flags=sinc+accurate_rnd]",
+                    self.config.snapshot_width, self.config.snapshot_height
+            ),
+            '-o=' .. output_path,
+            h.unpack(encoder_args)
     )
 end
 
@@ -381,8 +386,10 @@ mpv.make_animated_snapshot_args = function(source_path, output_path, start_times
         encoder_args = {
             '--ovc=libaom-av1',
             '--ovcopts-add=cpu-used=6', -- cpu-used < 6 can take a lot of time to encode.
-            string.format('--ovcopts-add=crf=%d',
-                          rescale_quality(self.config.snapshot_quality, self.max_avif_crf, 0)),
+            string.format(
+                    '--ovcopts-add=crf=%d',
+                    rescale_quality(self.config.snapshot_quality, self.max_avif_crf, 0)
+            ),
         }
     else
         encoder_args = {
@@ -393,18 +400,18 @@ mpv.make_animated_snapshot_args = function(source_path, output_path, start_times
     end
 
     return mpv.prepend_common_args(
-        source_path,
-        '--audio=no',
-        '--start=' .. toms(start_timestamp),
-        '--end=' .. toms(end_timestamp),
-        '--ofopts-add=loop=0',
-        string.format('--vf-add=fps=%d', self.config.animated_snapshot_fps),
-        string.format(
-            "--vf-add=lavfi=[scale='min(%d,iw)':'min(%d,ih)':flags=lanczos+accurate_rnd]",
-            self.config.animated_snapshot_width, self.config.animated_snapshot_height
-        ),
-        '-o=' .. output_path,
-        table.unpack(encoder_args)
+            source_path,
+            '--audio=no',
+            '--start=' .. toms(start_timestamp),
+            '--end=' .. toms(end_timestamp),
+            '--ofopts-add=loop=0',
+            string.format('--vf-add=fps=%d', self.config.animated_snapshot_fps),
+            string.format(
+                    "--vf-add=lavfi=[scale='min(%d,iw)':'min(%d,ih)':flags=lanczos+accurate_rnd]",
+                    self.config.animated_snapshot_width, self.config.animated_snapshot_height
+            ),
+            '-o=' .. output_path,
+            h.unpack(encoder_args)
     )
 end
 
@@ -420,17 +427,17 @@ mpv.make_audio_args = function(source_path, output_path,
 
     local function make_mpvargs(...)
         local args = mpv.prepend_common_args(
-            source_path,
-            '--video=no',
-            '--aid=' .. audio_track_id,
-            '--audio-channels=mono',
-            '--start=' .. toms(start_timestamp),
-            '--end=' .. toms(end_timestamp),
-            string.format(
-                '--volume=%d',
-                self.config.tie_volumes and mp.get_property('volume') or 100
-            ),
-            ...
+                source_path,
+                '--video=no',
+                '--aid=' .. audio_track_id,
+                '--audio-channels=mono',
+                '--start=' .. toms(start_timestamp),
+                '--end=' .. toms(end_timestamp),
+                string.format(
+                        '--volume=%d',
+                        self.config.tie_volumes and mp.get_property('volume') or 100
+                ),
+                ...
         )
         for arg in string.gmatch(self.config.mpv_audio_args, "%S+") do
             table.insert(args, arg)
@@ -460,9 +467,9 @@ mpv.make_audio_args = function(source_path, output_path,
         end
 
         local args = make_mpvargs(
-            '--oacopts-add=b=' .. self.config.audio_bitrate,
-            '-o=' .. output_path,
-            table.unpack(encoder_args)
+                '--oacopts-add=b=' .. self.config.audio_bitrate,
+                '-o=' .. output_path,
+                h.unpack(encoder_args)
         )
         if loudnorm_args then
             table.insert(args, '--af-append=' .. loudnorm_args)
@@ -477,23 +484,23 @@ mpv.make_audio_args = function(source_path, output_path,
 
     local loudnorm_targets = make_loudnorm_targets()
     h.subprocess(
-        make_mpvargs(
-            '-v',
-            '--af-append=' .. loudnorm_targets .. ':print_format=json',
-            '--ao=null',
-            '--of=null'
-        ),
-        parse_loudnorm(
-            loudnorm_targets,
-            function(stdout, stderr)
-                local start, stop, json = string.find(stdout, '%[ffmpeg%] ({.-})')
-                if json then
-                    json = string.gsub(json, '%[ffmpeg%]', '')
-                end
-                return json
-            end,
-            make_encoding_args
-        )
+            make_mpvargs(
+                    '-v',
+                    '--af-append=' .. loudnorm_targets .. ':print_format=json',
+                    '--ao=null',
+                    '--of=null'
+            ),
+            parse_loudnorm(
+                    loudnorm_targets,
+                    function(stdout, stderr)
+                        local start, stop, json = string.find(stdout, '%[ffmpeg%] ({.-})')
+                        if json then
+                            json = string.gsub(json, '%[ffmpeg%]', '')
+                        end
+                        return json
+                    end,
+                    make_encoding_args
+            )
     )
 end
 
@@ -586,7 +593,7 @@ local create_audio = function(start_timestamp, end_timestamp, filename, padding)
         end
 
         self.encoder.make_audio_args(
-            source_path, output_path, start_timestamp, end_timestamp, start_encoding)
+                source_path, output_path, start_timestamp, end_timestamp, start_encoding)
     else
         print("Audio will not be created.")
     end

--- a/subs2srs.lua
+++ b/subs2srs.lua
@@ -58,19 +58,21 @@ local config = {
     -- Snapshots
     snapshot_format = "avif", -- avif, webp or jpg
     snapshot_quality = 15, -- from 0=lowest to 100=highest
-    snapshot_width = -2, -- a positive integer or -2 for auto
+    snapshot_width = -1, -- a positive integer or -1 for auto
     snapshot_height = 200, -- same
     screenshot = false, -- create a screenshot instead of a snapshot; see example config.
 
     -- Animations
     animated_snapshot_enabled = false, -- if enabled captures the selected segment of the video, instead of just a frame
+    animated_snapshot_format = "avif", -- avif or webp
     animated_snapshot_fps = 10, -- positive integer between 0 and 30 (30 included)
-    animated_snapshot_width = -2, -- positive integer or -2 to scale it maintaining ratio (height must not be -2 in that case)
-    animated_snapshot_height = 200, -- positive integer or -2 to scale it maintaining ratio (width must not be -2 in that case)
+    animated_snapshot_width = -1, -- positive integer or -1 to scale it maintaining ratio (height must not be -1 in that case)
+    animated_snapshot_height = 200, -- positive integer or -1 to scale it maintaining ratio (width must not be -1 in that case)
     animated_snapshot_quality = 5, -- positive integer between 0 and 100 (100 included)
 
     -- Audio clips
     audio_format = "opus", -- opus or mp3
+    opus_container = "ogg", -- ogg, opus, m4a, webm or caf
     audio_bitrate = "18k", -- from 16k to 32k
     audio_padding = 0.12, -- Set a pad to the dialog timings. 0.5 = audio is padded by .5 seconds. 0 = disable.
     tie_volumes = false, -- if set to true, the volume of the outputted audio file depends on the volume of the player at the time of export
@@ -81,9 +83,15 @@ local config = {
     menu_font_size = 25,
     show_selected_text = true,
 
+    loudnorm = true,
+    loudnorm_target = -16,
+    loudnorm_range = 11,
+    loudnorm_peak = -1.5,
+
     -- Custom encoding args
-    ffmpeg_audio_args = '-af loudnorm=I=-16:TP=-1.5:LRA=11',
-    mpv_audio_args = '--af-append=loudnorm=I=-16:TP=-1.5:LRA=11',
+
+    ffmpeg_audio_args = '',
+    mpv_audio_args = '',
 
     -- Anki
     create_deck = false, -- automatically create a deck for new cards
@@ -179,6 +187,7 @@ local codec_support = (function()
 
     return {
         snapshot = {
+            ['libaom-av1'] = is_image_supported('libaom-av1'),
             libwebp = is_image_supported('libwebp'),
             mjpeg = is_image_supported('mjpeg'),
         },

--- a/subs2srs.lua
+++ b/subs2srs.lua
@@ -102,15 +102,20 @@ local config = {
     menu_font_size = 25,
     show_selected_text = true,
 
-    loudnorm = true,
+    -- Make sure to remove loudnorm from ffmpeg_audio_args and mpv_audio_args before enabling.
+    loudnorm = false,
     loudnorm_target = -16,
     loudnorm_range = 11,
     loudnorm_peak = -1.5,
 
     -- Custom encoding args
-
-    ffmpeg_audio_args = '',
-    mpv_audio_args = '',
+    -- Defaults are for backward compatibility, in case someone
+    -- updates mpvacious without updating their config.
+    -- Better to remove loudnorm from custom args and enable two-pass loudnorm.
+    -- Enabling loudnorm both through the separate switch and through custom args
+    -- can lead to unpredictable results.
+    ffmpeg_audio_args = '-af loudnorm=I=-16:TP=-1.5:LRA=11:dual_mono=true',
+    mpv_audio_args = '--af-append=loudnorm=I=-16:TP=-1.5:LRA=11:dual_mono=true',
 
     -- Anki
     create_deck = false, -- automatically create a deck for new cards

--- a/subs2srs.lua
+++ b/subs2srs.lua
@@ -35,6 +35,25 @@ Usage:
 For complete usage guide, see <https://github.com/Ajatt-Tools/mpvacious/blob/master/README.md>
 ]]
 
+local mp = require('mp')
+local utils = require('mp.utils')
+local OSD = require('osd_styler')
+local cfg_mgr = require('cfg_mgr')
+local encoder = require('encoder')
+local h = require('helpers')
+local Menu = require('menu')
+local ankiconnect = require('ankiconnect')
+local switch = require('utils.switch')
+local play_control = require('utils.play_control')
+local secondary_sid = require('subtitles.secondary_sid')
+local platform = require('platform.init')
+local forvo = require('utils.forvo')
+local subs_observer = require('subtitles.observer')
+local menu
+
+------------------------------------------------------------
+-- default config
+
 local config = {
     -- The user should not modify anything below.
 
@@ -58,16 +77,16 @@ local config = {
     -- Snapshots
     snapshot_format = "avif", -- avif, webp or jpg
     snapshot_quality = 15, -- from 0=lowest to 100=highest
-    snapshot_width = -1, -- a positive integer or -1 for auto
-    snapshot_height = 200, -- same
+    snapshot_width = cfg_mgr.preserve_aspect_ratio, -- a positive integer or -2 for auto
+    snapshot_height = cfg_mgr.default_height_px, -- same
     screenshot = false, -- create a screenshot instead of a snapshot; see example config.
 
     -- Animations
     animated_snapshot_enabled = false, -- if enabled captures the selected segment of the video, instead of just a frame
     animated_snapshot_format = "avif", -- avif or webp
     animated_snapshot_fps = 10, -- positive integer between 0 and 30 (30 included)
-    animated_snapshot_width = -1, -- positive integer or -1 to scale it maintaining ratio (height must not be -1 in that case)
-    animated_snapshot_height = 200, -- positive integer or -1 to scale it maintaining ratio (width must not be -1 in that case)
+    animated_snapshot_width = cfg_mgr.preserve_aspect_ratio, -- positive integer or -2 to scale it maintaining ratio (height must not be -2 in that case)
+    animated_snapshot_height = cfg_mgr.default_height_px, -- positive integer or -2 to scale it maintaining ratio (width must not be -2 in that case)
     animated_snapshot_quality = 5, -- positive integer between 0 and 100 (100 included)
 
     -- Audio clips
@@ -142,21 +161,6 @@ local profiles = {
     active = "subs2srs",
 }
 
-local mp = require('mp')
-local utils = require('mp.utils')
-local OSD = require('osd_styler')
-local cfg_mgr = require('cfg_mgr')
-local encoder = require('encoder')
-local h = require('helpers')
-local Menu = require('menu')
-local ankiconnect = require('ankiconnect')
-local switch = require('utils.switch')
-local play_control = require('utils.play_control')
-local secondary_sid = require('subtitles.secondary_sid')
-local platform = require('platform.init')
-local forvo = require('utils.forvo')
-local subs_observer = require('subtitles.observer')
-local menu
 
 ------------------------------------------------------------
 -- utility functions


### PR DESCRIPTION
Images:
1. The code no longer passes the options encoders doesn't expect to see: AVIF gets only AVIF-specific parameters, WEBP – only WEBP-specific ones etc.
2. Added support for animated AVIFs.
3. AVIF encoder's `cpu-used` is set to 6 compared to [the default of 1](https://ffmpeg.org/ffmpeg-codecs.html#Options-28). On my machine, values below 6 become increasing slower without much of an improvement when it comes to file size.

    FFmpeg CRF 15 (high quality) 937×400 still images: 3 MB per 10k images in exchange for 1.5 to 3 times slower encoding.
    | cpu-used | file size in bytes | encoding time |
    |--------- |--------------------|---------------|
    |        0 |              13776 |       18.535s |
    |        1 |              13870 |       11.344s |
    |        2 |              13800 |       11.296s |
    |        3 |              13725 |        6.772s |
    |        4 |              14046 |        5.515s |
    |        5 |              14017 |        4.839s |
    |        6 |              14177 |        4.433s |
    |        7 |              14177 |        4.495s |
    |        8 |              14177 |        4.479s |

    FFmpeg CRF 32 (medium quality) 937×400 2 seconds animations: 1 MB per 100 images is more noticable, but the encoding time becomes obscene very very quickly.
    | cpu-used | file size in bytes | encoding time |
    |--------- |--------------------|---------------|
    |        0 |              84534 |    10m18.072s |
    |        1 |              85875 |     3m30.353s |
    |        2 |              89661 |     1m18.690s |
    |        3 |              90883 |       30.647s |
    |        4 |              91230 |       21.556s |
    |        5 |              90856 |       12.933s |
    |        6 |              92153 |       10.921s |
    |        7 |              92153 |       10.892s |
    |        8 |              92153 |       10.882s |
5. Still image scaling now uses `sinc`, which is the best downscaling algorithm: https://stackoverflow.com/a/6171860. Animated images still use Lanczos.
6. Image scaling now uses accurate rounding.
7. `min()`s in scaling filter prevent image upscaling.
8. JPEG's quality is now correctly mapped into the range 2–31.
9. Image aspect ratio preserving scaling now uses -1 instead of -2. According to [FFmpeg docs](https://ffmpeg.org/ffmpeg-filters.html#Options-2), -n scale is here to ‘make sure that the calculated dimension is divisible by n.’ I don't quite understand while divisibility by 2 was needed in the first place.

Audio:
1. Opus phase inversion is disabled, which improves mono quality: https://ffmpeg.org/ffmpeg-codecs.html#Option-Mapping.
2. The point of Opus is Ogg is lost on me, considering that Opus has its own extension. Ogg files containing non-Vorbis data are confusing. The ability to choose an Opus container was added to fix this, though Ogg is still the default.
3. Implementation of Opus in CAF was fixed. Previously it produced CAF-encoded files with Ogg extension.
4. Support for M4A and Webm containers have been added as a CAF replacement for newer Apple devices.
5. MP3-encoder now uses ABR, which is recommended for low bitrates: https://wiki.hydrogenaud.io/index.php?title=LAME#Recommended_encoder_settings.
6. `loudnorm` now has a proper two-pass implementation. `dual_mono` is now enabled to account for mono downmixing: https://ffmpeg.org/ffmpeg-filters.html#loudnorm.

Miscellanea:
1. `append_user_audio_args` no longer moves the last argument on every insert.
2. Exit codes of FFmpeg and MPV are now checked before reporting a successful conversion. Checking for file presence is not enough: sometimes failed conversions result in zero-length files.
3. Common MPV calling code was extracted into a separate function.
4. MPV's `libaom-av1` support is now checked.