### PR TITLE
Fix: Convert codec support boolean to string for formatting

### DIFF
--- a/encoder/codec_support.lua
+++ b/encoder/codec_support.lua
@@ -33,7 +33,7 @@ local inspection_result = {
 }
 for type, codecs in pairs(inspection_result) do
     for codec, supported in pairs(codecs) do
-        mp.msg.info(string.format("mpv supports %s codec %s: %s", type, codec, supported))
+        mp.msg.info(string.format("mpv supports %s codec %s: %s", type, codec, tostring(supported)))
     end
 end
 


### PR DESCRIPTION
Fixes a string formatting error in `codec_support.lua` by explicitly converting the boolean `supported` variable to a string using `tostring()`. This ensures that `string.format` receives the expected string type.