### PR TITLE
Add support for ankiconnect api key

### DIFF
--- a/.github/RELEASE/subs2srs.conf
+++ b/.github/RELEASE/subs2srs.conf
@@ -45,6 +45,9 @@ menu_font_name=Noto Serif CJK JP
 # Change this if you have changed webBindAddress in AnkiConnect's settings.
 ankiconnect_url=127.0.0.1:8765
 
+# AnkiConnect server api key (optional)
+#ankiconnect_api_key=
+
 ##
 ## Toggleables.
 ## Possible values: `yes` or `no`.

--- a/ankiconnect.lua
+++ b/ankiconnect.lua
@@ -11,7 +11,7 @@ local h = require('helpers')
 local self = {}
 
 self.execute = function(request, completion_fn)
-    if self.config.ankiconnect_api_key ~= '' then
+    if not h.is_empty(self.config.ankiconnect_api_key) then
         request.key = self.config.ankiconnect_api_key
     end
 

--- a/ankiconnect.lua
+++ b/ankiconnect.lua
@@ -11,6 +11,10 @@ local h = require('helpers')
 local self = {}
 
 self.execute = function(request, completion_fn)
+    if self.config.ankiconnect_api_key ~= '' then
+        request.key = self.config.ankiconnect_api_key
+    end
+
     -- utils.format_json returns a string
     -- On error, request_json will contain "null", not nil.
     local request_json, error = utils.format_json(request)

--- a/subs2srs.lua
+++ b/subs2srs.lua
@@ -159,6 +159,7 @@ local config = {
     append_media = true, -- True to append video media after existing data, false to insert media before
     disable_gui_browse = false, -- Lets you disable anki browser manipulation by mpvacious.
     ankiconnect_url = '127.0.0.1:8765',
+    ankiconnect_api_key = '',
 
     -- Note tagging
     -- The tag(s) added to new notes. Spaces separate multiple tags.


### PR DESCRIPTION
Hello there! AnkiConnect allows [setting an api key](https://git.sr.ht/~foosoft/anki-connect#authentication) for use in authenticating requests, which is also supported by [rikaitan](https://github.com/Ajatt-Tools/rikaitan/blob/0292a54eb9ccc945faa923821372afda1e8452ee/ext/js/comm/anki-connect.js#L439)

This pr proposes to add support for it by way of adding an `ankiconnect_api_key` config option
