### PR TITLE
Display first field instead of note ID

### DIFF
--- a/subs2srs.lua
+++ b/subs2srs.lua
@@ -444,7 +444,15 @@ local function notify_user_on_finish(note_ids)
         h.notify(string.format("Updated %i notes.", #note_ids))
     else
         field_data = ankiconnect.get_note_fields(note_ids[1])[first_field]
-        h.notify(string.format("Updated note: %s.", field_data))
+        if not h.is_empty(field_data) then
+          local max_len = 20
+          if string.len(field_data) > max_len then
+            field_data = field_data:sub(1, max_len) .. "…"
+          end
+          h.notify(string.format("Updated note: %s.", field_data))
+        else
+          h.notify(string.format("Updated note #%s.", tostring(note_ids[1])))
+        end
     end
 end
 


### PR DESCRIPTION
I don't think showing the note ID is very useful. When updating cards it's a lot more useful to get a readable representation of the card, so you know that you actually updated the right card. 

Right now it just uses the first field, but I could also see this as a config option. In theory there could be a toggle for if you want to show field contents or the note ID, but I don't think the note ID is useful enough for that. 

@tatsumoto-ren What do you think? 