### PR TITLE
fix blank filename

### DIFF
--- a/utils/filename_factory.lua
+++ b/utils/filename_factory.lua
@@ -50,9 +50,18 @@ end)()
 local make_media_filename = function()
     filename = mp.get_property("filename") -- filename without path
     filename = h.remove_extension(filename)
-    filename = h.remove_filename_text_in_parentheses(filename)
-    filename = h.remove_text_in_brackets(filename)
-    filename = h.remove_special_characters(filename)
+
+    local operations = {
+        h.remove_filename_text_in_parentheses, 
+        h.remove_text_in_brackets, 
+        h.remove_special_characters
+    }
+    for _, f in ipairs(operations) do
+        local temp_filename = f(filename)
+        if temp_filename ~= "" then
+            filename = temp_filename
+        end
+    end
 end
 
 local function timestamp_range(start_timestamp, end_timestamp, extension)


### PR DESCRIPTION
I recently played some videos with filenames like `[DBD-Raws][Himouto! Umaru-chan][01][1080P][BDRip][HEVC-10bit][FLAC+AC3].mkv`. Because all the words are enclosed in brackets, mpvacious removes the entire filename, which makes media outputs become `_14m02s410ms_14m05s290ms.ogg`, `_12m08s770ms.avif`, etc.
A filename starting with an underscore has a special meaning in Anki, so it's better to correct this. 