### PR TITLE
fix: avoid duplicate field append on HTML entity mismatch

### DIFF
--- a/mpvacious/anki/note_exporter.lua
+++ b/mpvacious/anki/note_exporter.lua
@@ -189,6 +189,12 @@ local function make_exporter()
             return old_text
         end
 
+        if h.is_substr(h.unescape_special_characters(old_text), h.unescape_special_characters(new_text)) then
+            -- Avoid duplicate sentence/media content when equivalent HTML entities differ,
+            -- e.g. "'" versus "&apos;".
+            return old_text
+        end
+
         return string.format("%s%s%s", old_text, separator, new_text)
     end
 

--- a/mpvacious/helpers.lua
+++ b/mpvacious/helpers.lua
@@ -655,6 +655,7 @@ function this.run_tests()
     this.assert_equals(this.str_contains("abcd", "^.*z.*$"), false)
     this.assert_equals(this.unescape_special_characters("that&apos;s"), "that's")
     this.assert_equals(this.unescape_special_characters("that&#39;s &amp; &quot;ok&quot;"), "that's & \"ok\"")
+    this.assert_equals(this.unescape_special_characters("&lt;tag&gt;"), "<tag>")
 
     local ep_num_to_filename = {
         { nil, "A Whisker Away.mkv" },

--- a/mpvacious/helpers.lua
+++ b/mpvacious/helpers.lua
@@ -187,6 +187,27 @@ this.escape_special_characters = (function()
     end
 end)()
 
+this.unescape_special_characters = (function()
+    local entities = {
+        ['&apos;'] = "'",
+        ['&#39;'] = "'",
+        ['&quot;'] = '"',
+        ['&lt;'] = '<',
+        ['&gt;'] = '>',
+        ['&amp;'] = '&',
+    }
+    local patterns = { '&apos;', '&#39;', '&quot;', '&lt;', '&gt;', '&amp;' }
+    return function(s)
+        if this.is_empty(s) then
+            return s
+        end
+        for _, pattern in ipairs(patterns) do
+            s = s:gsub(pattern, entities[pattern])
+        end
+        return s
+    end
+end)()
+
 function this.remove_extension(filename)
     return filename:gsub('%.%w+$', '')
 end
@@ -632,6 +653,8 @@ function this.run_tests()
     this.assert_equals(this.is_substr("abcd", "^.*d.*$"), false)
     this.assert_equals(this.str_contains("abcd", "^.*d.*$"), true)
     this.assert_equals(this.str_contains("abcd", "^.*z.*$"), false)
+    this.assert_equals(this.unescape_special_characters("that&apos;s"), "that's")
+    this.assert_equals(this.unescape_special_characters("that&#39;s &amp; &quot;ok&quot;"), "that's & \"ok\"")
 
     local ep_num_to_filename = {
         { nil, "A Whisker Away.mkv" },

--- a/mpvacious/main.lua
+++ b/mpvacious/main.lua
@@ -596,6 +596,12 @@ local function run_tests()
     }
     local result_same_sentence = note_exporter.join_fields(new_note_same_sentence, old_note_same_sentence)
     h.assert_equals(result_same_sentence, old_note_same_sentence)
+
+    local new_note_same_sentence_numeric = {
+        SentKanji = "Well, that&#39;s the knighthood in the bag.",
+    }
+    local result_same_sentence_numeric = note_exporter.join_fields(new_note_same_sentence_numeric, old_note_same_sentence)
+    h.assert_equals(result_same_sentence_numeric, old_note_same_sentence)
 end
 
 local function pcall_tests()

--- a/mpvacious/main.lua
+++ b/mpvacious/main.lua
@@ -587,6 +587,15 @@ local function run_tests()
         Notes = "",
     }
     h.assert_equals(result, expected)
+
+    local old_note_same_sentence = {
+        SentKanji = "Well, that's the knighthood in the bag.",
+    }
+    local new_note_same_sentence = {
+        SentKanji = "Well, that&apos;s the knighthood in the bag.",
+    }
+    local result_same_sentence = note_exporter.join_fields(new_note_same_sentence, old_note_same_sentence)
+    h.assert_equals(result_same_sentence, old_note_same_sentence)
 end
 
 local function pcall_tests()


### PR DESCRIPTION
  This fixes a case where equivalent field content can be appended twice when the existing note field and the new field differ only by HTML entity encoding.

  A practical example is:

  - existing field: `Well, that's the knighthood in the bag.`
  - new field: `Well, that&apos;s the knighthood in the bag.`

  These strings render the same in Anki, but the previous join logic compared raw strings only, so the new content could be treated as different and appended again.

  This can happen when a note is first created by an external tool through AnkiConnect and later updated by mpvacious via `updateNoteFields`. In that case, one side may use literal characters while the other uses HTML entities such as `&apos;` or `&#39;`.

  This patch normalizes common HTML entities before substring comparison, so equivalent content is no longer appended twice.

  Changes:
  - add `unescape_special_characters()` for common HTML entities
  - compare normalized field content before appending
  - add regression coverage for:
    - `&apos;`
    - `&#39;`
    - `&amp;`
    - `&quot;`
    - `&lt;`
    - `&gt;`

  This looks similar in symptom to #139, but the root cause is different. That fix addressed duplicated updates caused by reused mutated note data, while this patch addresses duplication caused by HTML entity mismatch.