### PR TITLE
Avoid appending sentence_field on note updates

### DIFF
--- a/mpvacious/anki/note_exporter.lua
+++ b/mpvacious/anki/note_exporter.lua
@@ -174,22 +174,39 @@ local function make_exporter()
         return new_data
     end
 
-    local function join_field_content(new_text, old_text, separator)
-        -- By default, join fields with a HTML newline.
-        separator = separator or "<br>"
+    local function join_field_content(new_text, old_text, cfg)
+        cfg = cfg or {}
 
-        if h.is_empty(old_text) then
+        -- By default, join fields with a HTML newline.
+        cfg.separator = cfg.separator or "<br>"
+
+        local cmp_new_text, cmp_old_text = (function()
+            -- Primary and secondary subtitles are compared without html tags.
+            if cfg.plaintext_compare then
+                return h.remove_html_tags(new_text), h.remove_html_tags(old_text)
+            else
+                return new_text, old_text
+            end
+        end)()
+
+        if h.is_empty(cmp_old_text) then
             -- If 'old_text' is empty, there's no need to join content with the separator.
             return new_text
         end
 
-        if h.is_substr(old_text, new_text) then
+        if h.is_substr(cmp_old_text, cmp_new_text) then
             -- If 'old_text' (field) already contains new_text (sentence, image, audio, etc.),
             -- there's no need to add 'new_text' to 'old_text'.
             return old_text
         end
 
-        return string.format("%s%s%s", old_text, separator, new_text)
+        if h.is_substr(cmp_new_text, cmp_old_text) then
+            -- If 'new_text' (field) already contains old_text (sentence, image, audio, etc.),
+            -- there's no need to add 'new_text' to 'old_text'.
+            return new_text
+        end
+
+        return string.format("%s%s%s", old_text, cfg.separator, new_text)
     end
 
     local function fail_if_not_ready()
@@ -200,21 +217,31 @@ local function make_exporter()
 
     local function join_fields(new_data, stored_data)
         fail_if_not_ready()
-        -- sentence_field is handled separately by update_sentence() so target-word
-        -- markup can be preserved without duplicating the full sentence contents.
-        for _, field in pairs { self.config.audio_field, self.config.image_field, self.config.miscinfo_field, self.config.secondary_field } do
+        for _, field in pairs { self.config.audio_field, self.config.image_field, self.config.miscinfo_field } do
             if not h.is_empty(field) then
                 new_data[field] = join_field_content(h.table_get(new_data, field, ""), h.table_get(stored_data, field, ""))
             end
         end
+
+        for _, field in pairs { self.config.sentence_field, self.config.secondary_field } do
+            if not h.is_empty(field) then
+                -- Strip html tags to compare text only.
+                new_data[field] = join_field_content(h.table_get(new_data, field, ""), h.table_get(stored_data, field, ""), { plaintext_compare = true })
+            end
+        end
+
         return new_data
     end
 
-    local function make_new_note_data(stored_data, new_data, overwrite)
+    local function make_new_note_data(stored_data, new_data, cfg)
+        cfg = cfg or {}
+
         if stored_data then
-            new_data = self.forvo.append(new_data, stored_data)
+            if not cfg.disable_forvo then
+                new_data = self.forvo.append(new_data, stored_data)
+            end
             new_data = update_sentence(new_data, stored_data)
-            if not overwrite then
+            if not cfg.overwrite then
                 if self.config.append_media then
                     new_data = join_fields(new_data, stored_data)
                 else
@@ -236,7 +263,7 @@ local function make_exporter()
         for _, note_id in pairs(note_ids) do
             self.ankiconnect.append_media(
                     note_id,
-                    make_new_note_data(self.ankiconnect.get_note_fields(note_id), h.deep_copy(new_data), overwrite),
+                    make_new_note_data(self.ankiconnect.get_note_fields(note_id), h.deep_copy(new_data), { overwrite = overwrite }),
                     substitute_fmt(self.config.note_tag),
                     change_notes_countdown.decrease
             )
@@ -367,6 +394,49 @@ local function make_exporter()
         self.forvo = forvo
     end
 
+    local function run_tests()
+        -- Test join_field_content
+        h.assert_equals(join_field_content("ヤツらの声に現実味が…", "あの遠さはヤツらの声に現実味が…"), "あの遠さはヤツらの声に現実味が…")
+        h.assert_equals(join_field_content("あの遠さはヤツらの声に現実味が…", "ヤツらの声に現実味が…"), "あの遠さはヤツらの声に現実味が…")
+
+        -- Test join_fields
+        local new_note = {
+            SentKanji = "それは…分からんよ",
+            SentAudio = "[sound:s01e13_02m25s010ms_02m27s640ms.ogg]",
+            SentEng = "Well...",
+            Image = '<img alt="snapshot" src="s01e13_02m25s561ms.avif">'
+        }
+        local old_note = {
+            SentAudio = "[sound:s01e13_02m21s340ms_02m24s140ms.ogg]",
+            Image = '<img alt="snapshot" src="s01e13_02m22s225ms.avif">',
+            VocabAudio = "",
+            Notes = "",
+            VocabDef = "",
+            SentKanji = "勝ちって何に？",
+            SentEng = "What would we win, exactly?",
+        }
+        local expected = {
+            SentKanji = "勝ちって何に？<br>それは…分からんよ",
+            SentAudio = "[sound:s01e13_02m21s340ms_02m24s140ms.ogg]<br>[sound:s01e13_02m25s010ms_02m27s640ms.ogg]",
+            SentEng = "What would we win, exactly?<br>Well...",
+            Image = '<img alt="snapshot" src="s01e13_02m22s225ms.avif"><br><img alt="snapshot" src="s01e13_02m25s561ms.avif">',
+            Notes = "",
+        }
+        h.assert_equals(join_fields(new_note, old_note), expected)
+
+        -- Test make_new_note_data
+        old_note = {
+            SentKanji = "ヤツらの声に<b>現実味</b>が…",
+        }
+        new_note = {
+            SentKanji = "あの遠さはヤツらの声に現実味が…",
+        }
+        expected = {
+            SentKanji = "あの遠さはヤツらの声に<b>現実味</b>が…",
+        }
+        h.assert_equals(make_new_note_data(old_note, new_note, { overwrite = false, disable_forvo = true }).SentKanji, expected.SentKanji)
+    end
+
     return {
         init = init,
         update_notes = update_notes,
@@ -375,6 +445,7 @@ local function make_exporter()
         join_fields = join_fields,
         update_last_note = update_last_note,
         update_selected_note = update_selected_note,
+        run_tests = run_tests,
     }
 end
 

--- a/mpvacious/anki/note_exporter.lua
+++ b/mpvacious/anki/note_exporter.lua
@@ -174,6 +174,7 @@ local function make_exporter()
         return new_data
     end
 
+    --- expected cfg fields: str separator, bool plaintext_compare
     local function join_field_content(new_text, old_text, cfg)
         cfg = cfg or {}
 
@@ -233,6 +234,7 @@ local function make_exporter()
         return new_data
     end
 
+    --- expected cfg fields: bool disable_forvo, bool overwrite
     local function make_new_note_data(stored_data, new_data, cfg)
         cfg = cfg or {}
 

--- a/mpvacious/anki/note_exporter.lua
+++ b/mpvacious/anki/note_exporter.lua
@@ -200,7 +200,9 @@ local function make_exporter()
 
     local function join_fields(new_data, stored_data)
         fail_if_not_ready()
-        for _, field in pairs { self.config.audio_field, self.config.image_field, self.config.miscinfo_field, self.config.sentence_field, self.config.secondary_field } do
+        -- sentence_field is handled separately by update_sentence() so target-word
+        -- markup can be preserved without duplicating the full sentence contents.
+        for _, field in pairs { self.config.audio_field, self.config.image_field, self.config.miscinfo_field, self.config.secondary_field } do
             if not h.is_empty(field) then
                 new_data[field] = join_field_content(h.table_get(new_data, field, ""), h.table_get(stored_data, field, ""))
             end

--- a/mpvacious/helpers.lua
+++ b/mpvacious/helpers.lua
@@ -203,6 +203,10 @@ function this.remove_filename_text_in_parentheses(str)
     return str:gsub('%b()', ''):gsub('（.-）', '')
 end
 
+function this.remove_html_tags(str)
+    return str:gsub('<[^<>]+>', '')
+end
+
 function this.remove_common_resolutions(str)
     -- Also removes empty leftover parentheses and brackets.
     return str:gsub("2160p", ""):gsub("1080p", ""):gsub("720p", ""):gsub("576p", ""):gsub("480p", ""):gsub("%(%)", ""):gsub("%[%]", "")
@@ -312,13 +316,17 @@ function this.file_exists(filepath)
     return false
 end
 
+function this.repr(value)
+    if type(value) == 'table' then
+        return utils.format_json(value)
+    else
+        return value
+    end
+end
+
 function this.equal(first, last)
     --- Test whether two values are equal
-    if type(last) == 'table' then
-        return (utils.format_json(first) == utils.format_json(last))
-    else
-        return (first == last)
-    end
+    return this.repr(first) == this.repr(last)
 end
 
 function this.get_loaded_tracks(track_type)
@@ -331,7 +339,7 @@ end
 
 function this.assert_equals(actual, expected)
     if this.equal(actual, expected) == false then
-        error(string.format("TEST FAILED: Expected '%s', got '%s'", expected, actual))
+        error(string.format("TEST FAILED: Expected '%s', got '%s'", this.repr(expected), this.repr(actual)))
     end
 end
 
@@ -729,6 +737,12 @@ function this.run_tests()
     this.assert_equals(this.join_two_sorted_lists({}, {}), {})
     this.assert_equals(this.join_two_sorted_lists({ 1 }, { 2 }), { 1, 2 })
     this.assert_equals(this.join_two_sorted_lists({ 1, 1, 2 }, { 1, 3, 3 }), { 1, 1, 1, 2, 3, 3 })
+
+    -- Test this.remove_html_tags(str)
+    this.assert_equals(this.remove_html_tags("ヤツらの声に<b>現実味</b>が…"), "ヤツらの声に現実味が…")
+    this.assert_equals(this.remove_html_tags("ヤツらの声に<span>現実味</span>が…"), "ヤツらの声に現実味が…")
+    this.assert_equals(this.remove_html_tags("<b><b><b><b>"), "")
+    this.assert_equals(this.remove_html_tags("<a href=\"test\">test</a>"), "test")
 end
 
 return this

--- a/mpvacious/main.lua
+++ b/mpvacious/main.lua
@@ -563,30 +563,7 @@ end
 
 local function run_tests()
     h.run_tests()
-    local new_note = {
-        SentKanji = "それは…分からんよ",
-        SentAudio = "[sound:s01e13_02m25s010ms_02m27s640ms.ogg]",
-        SentEng = "Well...",
-        Image = '<img alt="snapshot" src="s01e13_02m25s561ms.avif">'
-    }
-    local old_note = {
-        SentAudio = "[sound:s01e13_02m21s340ms_02m24s140ms.ogg]",
-        Image = '<img alt="snapshot" src="s01e13_02m22s225ms.avif">',
-        VocabAudio = "",
-        Notes = "",
-        VocabDef = "",
-        SentKanji = "勝ちって何に？",
-        SentEng = "What would we win, exactly?",
-    }
-    local result = note_exporter.join_fields(new_note, old_note)
-    local expected = {
-        SentKanji = "勝ちって何に？<br>それは…分からんよ",
-        SentAudio = "[sound:s01e13_02m21s340ms_02m24s140ms.ogg]<br>[sound:s01e13_02m25s010ms_02m27s640ms.ogg]",
-        SentEng = "What would we win, exactly?<br>Well...",
-        Image = '<img alt="snapshot" src="s01e13_02m22s225ms.avif"><br><img alt="snapshot" src="s01e13_02m25s561ms.avif">',
-        Notes = "",
-    }
-    h.assert_equals(result, expected)
+    note_exporter.run_tests()
 end
 
 local function pcall_tests()


### PR DESCRIPTION
## Summary

This changes append-mode note updates so they stop appending `sentence_field`.

## Problem

The README says append mode should append to media fields:

- `Ctrl+m` - append to the media fields of the newly added note
- `Ctrl+b` - append to the media fields of selected notes

However, the current implementation also appends `sentence_field`.

This causes duplicated sentence content when updating notes created externally, for example by Rikaitan with the new note timer enabled.

Example:

- existing sentence from Rikaitan:

```html
ヤツらの声に<b>現実味</b>が…
```

- fuller sentence captured by mpvacious:

```html
あの遠さはヤツらの声に現実味が…
```

- current append-mode result:

```html
ヤツらの声に<b>現実味</b>が…<br>あの遠さはヤツらの声に<b>現実味</b>が…
```

The existing `update_sentence()` logic already preserves target-word markup from the stored sentence field. Appending the full sentence field afterward defeats that behavior by concatenating the old and new sentences together.

This also aligns with the existing comment in `update_sentence()`:

- "if the target word was marked by Rikaitan, this function makes sure that the highlighting doesn't get erased."

That comment implies sentence updates should preserve the marked target in the updated sentence, not concatenate both the old and new sentence text.

## Fix

Restrict append-mode field joining to:

- `audio_field`
- `image_field`
- `miscinfo_field`
- `secondary_field`

Leave sentence text handling to `update_sentence()`, which preserves existing target-word markup without duplicating the sentence contents.

## Result

Append mode still appends media, but sentence updates now produce the expected single sentence with preserved highlighting, e.g.:

```html
あの遠さはヤツらの声に<b>現実味</b>が…
```
