### PR TITLE
Fix ffmpeg snapshot aspect ratio with auto width

### DIFF
--- a/mpvacious/encoder/utils.lua
+++ b/mpvacious/encoder/utils.lua
@@ -41,6 +41,18 @@ local function make_scale_filter(algorithm, width, height)
     -- algorithm is either "sinc" or "lanczos"
     -- Static image scaling uses "sinc", which is the best downscaling algorithm: https://stackoverflow.com/a/6171860
     -- Animated images use Lanczos, which is faster.
+    if width == -2 and height > 0 then
+        return string.format(
+                "scale='trunc(min(%d,ih)*dar/2+0.5)*2':'min(%d,ih)':flags=%s+accurate_rnd,setsar=1",
+                height, height, algorithm
+        )
+    end
+    if height == -2 and width > 0 then
+        return string.format(
+                "scale='trunc(min(%d,iw*sar)/2+0.5)*2':'trunc(min(%d,iw*sar)/dar/2+0.5)*2':flags=%s+accurate_rnd,setsar=1",
+                width, width, algorithm
+        )
+    end
     return string.format(
             "scale='min(%d,iw)':'min(%d,ih)':flags=%s+accurate_rnd",
             width, height, algorithm


### PR DESCRIPTION
I was trying to create cards with 480px height and auto width.

- Source video: `1280x720 SAR 3:4 DAR 4:3`
- Expected WebP: `640x480 SAR 1:1`
- Actual result before this fix: `854x480`, which appears stretched as WebP

Here is the config I was using:

```conf
use_ffmpeg=yes
snapshot_format=webp
snapshot_width=-2
snapshot_height=480
```

This changes the auto-dimension scale filter to calculate the output size from the display aspect ratio and normalize the snapshot with setsar=1.