### PR TITLE
fix custom subtitle filter not handling multi-line subtitles correctly

### DIFF
--- a/mpvacious/subtitles/sub_list.lua
+++ b/mpvacious/subtitles/sub_list.lua
@@ -19,7 +19,7 @@ local new_sub_list = function()
         for _, sub in ipairs(subs_list) do
             table.insert(speech, sub['text'])
         end
-        return table.concat(speech, ' ')
+        return table.concat(speech, '\n')
     end
     local get_n_text = function(sub, n_lines)
         local speech = {}
@@ -33,7 +33,7 @@ local new_sub_list = function()
                 end_sub = v
             end
         end
-        return table.concat(speech, ' '), end_sub
+        return table.concat(speech, '\n'), end_sub
     end
     local insert = function(sub)
         if sub == nil or h.is_empty(sub.text) then

--- a/mpvacious/subtitles/sub_list.lua
+++ b/mpvacious/subtitles/sub_list.lua
@@ -6,6 +6,7 @@ Subtitle list remembers selected subtitle lines.
 ]]
 
 local h = require('helpers')
+local CONCAT_CHR = '\n' -- character used to concatenate subtitle lines
 
 local new_sub_list = function()
     local subs_list = {}
@@ -19,7 +20,7 @@ local new_sub_list = function()
         for _, sub in ipairs(subs_list) do
             table.insert(speech, sub['text'])
         end
-        return table.concat(speech, '\n')
+        return table.concat(speech, CONCAT_CHR)
     end
     local get_n_text = function(sub, n_lines)
         local speech = {}
@@ -33,7 +34,7 @@ local new_sub_list = function()
                 end_sub = v
             end
         end
-        return table.concat(speech, '\n'), end_sub
+        return table.concat(speech, CONCAT_CHR), end_sub
     end
     local insert = function(sub)
         if sub == nil or h.is_empty(sub.text) then


### PR DESCRIPTION
For example, if there are two subtitles like

```
AAAA
BBBB
```

i want to extract all AAAA lines from it.
previously, the two functions `get_text` and `get_n_text` concatenated them as: 
```
AAAA
BBBB AAAA
BBBB
```
which is hard to deal with.

This PR changes it to this form:
```
AAAA
BBBB
AAAA
BBBB
```

Since it will be trimmed afterwards, everything else will remain the same.