### PR TITLE
fix: deduplicate secondary subtitle lines

### DIFF
--- a/mpvacious/helpers.lua
+++ b/mpvacious/helpers.lua
@@ -65,6 +65,19 @@ function this.contains(table, element)
     return false
 end
 
+--- Return true if two array-like tables have the same length and equal elements.
+function this.list_equal(first, second)
+    if #first ~= #second then
+        return false
+    end
+    for i = 1, #first do
+        if first[i] ~= second[i] then
+            return false
+        end
+    end
+    return true
+end
+
 function this.minutes_ago(m)
     return (os.time() - 60 * m) * 1000
 end
@@ -743,6 +756,23 @@ local function test_islice()
     end
 end
 
+local function test_list_equal()
+    local list_equal_cases = {
+        { { 1, 2, 3 }, { 1, 2, 3 }, true }, -- identical lists
+        { { 1, 2 }, { 1, 2, 3 }, false }, -- different lengths
+        { { 1, 2, 3 }, { 1, 2 }, false }, -- different lengths, other direction
+        { { 1, 2, 3 }, { 1, 9, 3 }, false }, -- same length, different element
+        { {}, {}, true }, -- both empty
+        { { "a", "b" }, { "a", "b" }, true }, -- string elements
+        { { "a" }, { "A" }, false }, -- exact (case-sensitive) match
+        { { 1, 2 }, { 2, 1 }, false }, -- order matters
+    }
+    for _, case in ipairs(list_equal_cases) do
+        local first, second, expected = this.unpack(case)
+        this.assert_equals(this.list_equal(first, second), expected)
+    end
+end
+
 function this.run_tests()
     -- Test is_substr
     this.assert_equals(this.is_substr("abcd", "bc"), true)
@@ -795,6 +825,9 @@ function this.run_tests()
     end
 
     this.assert_equals(this.join_lists({ 1, 2 }, { 3 }, {}, { 4, 5 }), { 1, 2, 3, 4, 5 })
+
+    -- Test list_equal
+    test_list_equal()
 
     local t1 = { 1, 2, 3 }
     local t2 = { 3, 4, 5 }

--- a/mpvacious/main.lua
+++ b/mpvacious/main.lua
@@ -58,6 +58,7 @@ local make_note_exporter = require('anki.note_exporter')
 local Subtitle = require('subtitles.subtitle')
 local sub_list = require('subtitles.sub_list')
 local make_release_checker = require('utils.release_checker')
+local speech_collector = require('subtitles.collector')
 
 local quick_creation_opts = {
     _n_lines = nil,
@@ -573,6 +574,7 @@ local function run_tests()
     Subtitle.run_tests()
     sub_list.run_tests()
     make_note_exporter.run_tests(note_exporter)
+    speech_collector.run_tests()
 end
 
 local function pcall_tests()

--- a/mpvacious/subtitles/collector.lua
+++ b/mpvacious/subtitles/collector.lua
@@ -31,7 +31,7 @@ end
 --- Return true when two subtitle events overlap or touch in time.
 --- The collector assumes subtitles are appended in sorted order.
 local function do_subs_overlap_in_time(previous_sub, current_sub)
-    return previous_sub and current_sub and previous_sub['end'] >= current_sub['start']
+    return previous_sub and current_sub and previous_sub:overlaps_or_touches_in_time(current_sub)
 end
 
 --- Return how many lines at the end of recorded_lines are repeated at the start of lines_to_append.

--- a/mpvacious/subtitles/collector.lua
+++ b/mpvacious/subtitles/collector.lua
@@ -1,0 +1,146 @@
+--[[
+Copyright: Ajatt-Tools and contributors; https://github.com/Ajatt-Tools
+License: GNU GPL, version 3 or later; http://www.gnu.org/licenses/gpl.html
+
+Collect subtitle lines into a joined speech.
+]]
+
+local h = require('helpers')
+local Subtitle = require('subtitles.subtitle')
+local this = {}
+local CONCAT_CHR = '\n' -- character used to concatenate subtitle lines
+
+--- Split text into individual lines, normalized to LF.
+--- Empty lines are preserved so intentional subtitle formatting survives joining.
+local function normalized_lines(text)
+    local lines = {}
+    local normalized_text = text:gsub('\r\n', '\n'):gsub('\r', '\n')
+    -- Matches zero or more characters followed by a newline.
+    -- Keep empty lines so intentional subtitle formatting survives joining.
+    for line in (normalized_text .. '\n'):gmatch('(.-)\n') do
+        table.insert(lines, line)
+    end
+    -- Splitting works by appending a newline, so text that already ends with one
+    -- would produce an extra empty line unless we remove it here.
+    if normalized_text:sub(-1) == '\n' then
+        lines[#lines] = nil
+    end
+    return lines
+end
+
+--- Return true when two subtitle events overlap or touch in time.
+--- The collector assumes subtitles are appended in sorted order.
+local function do_subs_overlap_in_time(previous_sub, current_sub)
+    return previous_sub and current_sub and previous_sub['end'] >= current_sub['start']
+end
+
+--- Return how many lines at the end of recorded_lines are repeated at the start of lines_to_append.
+--- Only the boundary between the two lists is considered: a line repeated anywhere else does not count.
+local function count_overlapping_lines(recorded_lines, lines_to_append)
+    -- Start with the largest possible overlap (bounded by the shorter list)
+    -- and shrink it until the boundary lines match (or nothing is left).
+    local max_overlap = math.min(#recorded_lines, #lines_to_append)
+    for overlap_size = max_overlap, 1, -1 do
+        -- Compare the last overlap_size lines of recorded_lines
+        -- with the first overlap_size lines of lines_to_append.
+        if h.list_equal(h.itable_slice(recorded_lines, -overlap_size), h.itable_slice(lines_to_append, 1, overlap_size)) then
+            return overlap_size
+        end
+    end
+    return 0
+end
+
+--- Collect subtitle lines into a joined speech, removing boundary overlap
+--- between consecutive time-overlapping or touching subs.
+function this.make_speech_collector()
+    local self = {}
+    local recorded_lines = {}
+    local previous_sub -- store last recorded sub (with timings, unlike recorded_lines)
+
+    --- Append a sub's lines to speech, skipping leading lines that duplicate
+    --- the trailing lines of speech. Skipping applies only when the two subs
+    --- overlap or touch in time; a repeated line after a gap is kept as separate dialogue.
+    function self.append_sub(sub)
+        local lines_to_append = normalized_lines(sub['text'])
+        local n_lines_to_skip = 0
+        if do_subs_overlap_in_time(previous_sub, sub) then
+            n_lines_to_skip = count_overlapping_lines(recorded_lines, lines_to_append)
+        end
+        for i = n_lines_to_skip + 1, #lines_to_append do
+            table.insert(recorded_lines, lines_to_append[i])
+        end
+        previous_sub = sub
+    end
+
+    --- Return all collected lines joined with the subtitle line separator.
+    function self.get_all_as_string()
+        return table.concat(recorded_lines, CONCAT_CHR)
+    end
+
+    return self
+end
+
+local function test_count_overlapping_lines()
+    local cases = {
+        -- {recorded_lines, lines_to_append, expected}
+        { { "Yes", "No" }, { "No", "Maybe" }, 1 }, -- one shared boundary line
+        { { "A", "B", "C" }, { "B", "C", "D" }, 2 }, -- multi-line boundary overlap
+        { { "A", "B" }, { "A", "B" }, 2 }, -- full overlap
+        { { "A", "B", "C", "D" }, { "C", "D" }, 2 }, -- bounded by the shorter list
+        { { "X", "A", "B" }, { "A", "B", "C" }, 2 }, -- larger candidate fails, smaller matches
+        { { "A", "B" }, { "C", "D" }, 0 }, -- no overlap
+        { {}, { "A" }, 0 }, -- empty recorded_lines
+        { { "A" }, {}, 0 }, -- empty lines_to_append
+        { {}, {}, 0 }, -- both empty
+        { { "A", "B", "C" }, { "A", "D" }, 0 }, -- "A" is in recorded_lines but not at the boundary
+        { { "B" }, { "A", "B" }, 0 }, -- "B" ends recorded_lines but doesn't start lines_to_append
+        { { "a" }, { "A" }, 0 }, -- exact (case-sensitive) match
+    }
+    for _, case in ipairs(cases) do
+        local recorded_lines, lines_to_append, expected = h.unpack(case)
+        h.assert_equals(count_overlapping_lines(recorded_lines, lines_to_append), expected)
+    end
+end
+
+local function test_speech_collector_removes_boundary_overlap()
+    local collector = this.make_speech_collector()
+    collector.append_sub(Subtitle:from_text("First line", 0, 1))
+    collector.append_sub(Subtitle:from_text("First line\nSecond line", 1, 2))
+    h.assert_equals(collector.get_all_as_string(), "First line\nSecond line")
+end
+
+local function test_speech_collector_keeps_repeated_text_after_gap()
+    local collector = this.make_speech_collector()
+    collector.append_sub(Subtitle:from_text("Same line", 0, 1))
+    collector.append_sub(Subtitle:from_text("Same line", 2, 3))
+    h.assert_equals(collector.get_all_as_string(), "Same line\nSame line")
+end
+
+local function test_speech_collector_normalizes_newlines()
+    local collector = this.make_speech_collector()
+    collector.append_sub(Subtitle:from_text("First line\r\nSecond line\rThird line", 0, 1))
+    h.assert_equals(collector.get_all_as_string(), "First line\nSecond line\nThird line")
+end
+
+local function test_speech_collector_preserves_empty_lines()
+    local collector = this.make_speech_collector()
+    collector.append_sub(Subtitle:from_text("First line\n\nSecond line", 0, 1))
+    h.assert_equals(collector.get_all_as_string(), "First line\n\nSecond line")
+end
+
+local function test_speech_collector_drops_trailing_newline()
+    local collector = this.make_speech_collector()
+    collector.append_sub(Subtitle:from_text("First line\nSecond line\n", 0, 1))
+    h.assert_equals(collector.get_all_as_string(), "First line\nSecond line")
+end
+
+function this.run_tests()
+    test_count_overlapping_lines()
+    test_speech_collector_removes_boundary_overlap()
+    test_speech_collector_keeps_repeated_text_after_gap()
+    test_speech_collector_normalizes_newlines()
+    test_speech_collector_preserves_empty_lines()
+    test_speech_collector_drops_trailing_newline()
+end
+
+return this

--- a/mpvacious/subtitles/observer.lua
+++ b/mpvacious/subtitles/observer.lua
@@ -238,12 +238,7 @@ self.collect_from_all_dialogues = function(n_lines)
         return Subtitle:new() -- return a default empty new Subtitle to let consumer handle
     end
     local text, end_sub = all_dialogs.get_n_text(current_sub, n_lines)
-    local secondary_text, _
-    if current_secondary_sub == nil then
-        secondary_text = ''
-    else
-        secondary_text, _ = all_secondary_dialogs.get_n_text(current_secondary_sub, n_lines) -- we'll use main sub's timing
-    end
+    local secondary_text = all_secondary_dialogs.get_overlapping_text(current_sub['start'], end_sub['end'])
     return Subtitle:new {
         ['text'] = text,
         ['secondary'] = secondary_text,
@@ -261,11 +256,13 @@ self.collect_from_current = function()
     if secondary_dialogs.is_empty() then
         secondary_dialogs.insert(Subtitle:now('secondary'))
     end
+    local start_time = self.get_timing('start')
+    local end_time = self.get_timing('end')
     return Subtitle:new {
         ['text'] = dialogs.get_text(),
-        ['secondary'] = secondary_dialogs.get_text(),
-        ['start'] = self.get_timing('start'),
-        ['end'] = self.get_timing('end'),
+        ['secondary'] = secondary_dialogs.get_overlapping_text(start_time, end_time),
+        ['start'] = start_time,
+        ['end'] = end_time,
     }
 end
 

--- a/mpvacious/subtitles/observer.lua
+++ b/mpvacious/subtitles/observer.lua
@@ -70,7 +70,7 @@ end)
 
 autoclip_method.register_handler('goldendict', function(current_subtitle_lines)
     h.subprocess_detached {
-        args = {'goldendict', current_subtitle_lines.get_prepared().primary},
+        args = { 'goldendict', current_subtitle_lines.get_prepared().primary },
         completion_fn = on_external_finish
     }
 end)
@@ -237,13 +237,13 @@ self.collect_from_all_dialogues = function(n_lines)
     if current_sub == nil then
         return Subtitle:new() -- return a default empty new Subtitle to let consumer handle
     end
-    local text, end_sub = all_dialogs.get_n_text(current_sub, n_lines)
-    local secondary_text = all_secondary_dialogs.get_overlapping_text(current_sub['start'], end_sub['end'])
+    local combined = all_dialogs.collect_n_subs(current_sub, n_lines)
+    local secondary_text = all_secondary_dialogs.get_overlapping_text(combined)
     return Subtitle:new {
-        ['text'] = text,
+        ['text'] = combined["text"],
         ['secondary'] = secondary_text,
-        ['start'] = current_sub['start'],
-        ['end'] = end_sub['end'],
+        ['start'] = combined['start'],
+        ['end'] = combined['end'],
     }
 end
 
@@ -256,13 +256,12 @@ self.collect_from_current = function()
     if secondary_dialogs.is_empty() then
         secondary_dialogs.insert(Subtitle:now('secondary'))
     end
-    local start_time = self.get_timing('start')
-    local end_time = self.get_timing('end')
+    local combined = Subtitle:from_text(dialogs.get_text(), self.get_timing('start'), self.get_timing('end'))
     return Subtitle:new {
-        ['text'] = dialogs.get_text(),
-        ['secondary'] = secondary_dialogs.get_overlapping_text(start_time, end_time),
-        ['start'] = start_time,
-        ['end'] = end_time,
+        ['text'] = combined['text'],
+        ['secondary'] = secondary_dialogs.get_overlapping_text(combined),
+        ['start'] = combined['start'],
+        ['end'] = combined['end'],
     }
 end
 

--- a/mpvacious/subtitles/sub_list.lua
+++ b/mpvacious/subtitles/sub_list.lua
@@ -7,81 +7,58 @@ Subtitle list remembers selected subtitle lines.
 
 local h = require('helpers')
 local Subtitle = require('subtitles.subtitle')
-local CONCAT_CHR = '\n' -- character used to concatenate subtitle lines
+local speech_collector = require('subtitles.collector')
 local LOOKUP_WINDOW_SIZE = 25 -- how many recent subs to scan for duplicate events
 local MAX_SUB_GAP_SECONDS = 20 -- stop joining lines separated by a longer gap
 
 local new_sub_list = function()
     local subs_list = {}
 
-    local append_text = function(speech, previous_sub, sub)
-        local lines = {}
-        local text = sub['text']:gsub('\r\n', '\n'):gsub('\r', '\n')
-        for line in (text .. '\n'):gmatch('(.-)\n') do
-            table.insert(lines, line)
-        end
-
-        local overlap = previous_sub and sub['start'] <= previous_sub['end'] and math.min(#speech, #lines) or 0
-        while overlap > 0 do
-            local matches = true
-            for i = 1, overlap do
-                if speech[#speech - overlap + i] ~= lines[i] then
-                    matches = false
-                    break
-                end
-            end
-            if matches then
-                break
-            end
-            overlap = overlap - 1
-        end
-        for i = overlap + 1, #lines do
-            table.insert(speech, lines[i])
-        end
-    end
-
     local get_time = function(position)
         local i = position == 'start' and 1 or #subs_list
         return subs_list[i][position]
     end
     local get_text = function()
-        local speech = {}
-        local previous_sub = nil
+        -- Dedup applies to every list (primary, secondary), collapsing adjacent
+        -- multiline sub expansions into one continuous dialog string.
+        local collector = speech_collector.make_speech_collector()
         for _, sub in ipairs(subs_list) do
-            append_text(speech, previous_sub, sub)
-            previous_sub = sub
+            collector.append_sub(sub)
         end
-        return table.concat(speech, CONCAT_CHR)
+        return collector.get_all_as_string()
     end
     local get_n_text = function(sub, n_lines)
-        local speech = {}
+        local collector = speech_collector.make_speech_collector()
         local end_sub = sub
-        local previous_sub = nil
         local n_subs = 0
         for _, v in ipairs(subs_list) do
             if v['start'] - end_sub['end'] >= MAX_SUB_GAP_SECONDS then
                 break
             end
-            if v >= sub and n_subs < n_lines then
-                append_text(speech, previous_sub, v)
-                previous_sub = v
+            if not (v < sub) and n_subs < n_lines then
+                collector.append_sub(v)
                 end_sub = v
                 n_subs = n_subs + 1
             end
         end
-        return table.concat(speech, CONCAT_CHR), end_sub
+        return collector.get_all_as_string(), end_sub
     end
     local get_overlapping_text = function(start_time, end_time)
-        local speech = {}
-        local previous_sub = nil
+        local collector = speech_collector.make_speech_collector()
         for _, sub in ipairs(subs_list) do
             if sub['start'] < end_time and sub['end'] > start_time then
-                append_text(speech, previous_sub, sub)
-                previous_sub = sub
+                collector.append_sub(sub)
             end
         end
-        return table.concat(speech, CONCAT_CHR):gsub('%s+', ' '):match('^%s*(.-)%s*$')
+        return collector.get_all_as_string():gsub('%s+', ' '):match('^%s*(.-)%s*$')
     end
+    -- Event-level guard and expansion.
+    -- The same sub event is offered repeatedly (on every sub change and on
+    -- every collect call); exact duplicates (same text and timing) are skipped.
+    -- An adjacent same-text event (overlapping or touching in time) expands
+    -- the last recorded sub's end time.
+    -- Text-overlap cleanup for multiline expansion is intentionally delayed
+    -- until get_text()/get_n_text(), where the selected output window is known.
     local insert = function(sub)
         if sub == nil or h.is_empty(sub.text) then
             return false
@@ -103,6 +80,7 @@ local new_sub_list = function()
         return true
     end
     local get_subs_list = function()
+        -- Return a shallow copy so callers can't mutate the internal list.
         local copy = {}
         for key, value in pairs(subs_list) do
             copy[key] = value
@@ -135,7 +113,7 @@ local function make_numbered_sub_list(first_index, last_index)
 end
 
 local function assert_subs_sorted(subs)
-    local previous = nil
+    local previous
     for _, sub in ipairs(subs) do
         if previous and not (previous < sub) then
             error("list is not sorted")
@@ -252,20 +230,95 @@ local function test_get_subs_list_returns_array_copy()
     h.assert_equals(subs.get_subs_list()[1]['text'], "First line")
 end
 
-local function test_text_collection_removes_only_consecutive_line_overlap()
-    local growing = new_sub_list()
-    local first = Subtitle:from_text("First line", 0, 1)
-    growing.insert(first)
-    growing.insert(Subtitle:from_text("First line\nSecond line", 1, 2))
-    h.assert_equals(growing.get_text(), "First line\nSecond line")
-    h.assert_equals(growing.get_n_text(first, 2), "First line\nSecond line")
-
+local function test_get_text()
+    local first = Subtitle:from_text("First line", 0, 2)
+    local expanded = Subtitle:from_text("First line\nSecond line", 1, 3)
     local subs = new_sub_list()
-    subs.insert(Subtitle:from_text("Yes", 0, 1))
-    subs.insert(Subtitle:from_text("No", 1, 2))
-    subs.insert(Subtitle:from_text("Yes\nAgain", 2, 3))
-    h.assert_equals(subs.get_text(), "Yes\nNo\nYes\nAgain")
-    h.assert_equals(subs.get_n_text(subs.get_subs_list()[1], 3), "Yes\nNo\nYes\nAgain")
+    subs.insert(first)
+    subs.insert(expanded)
+    h.assert_equals(subs.get_text(), "First line\nSecond line")
+
+    -- The second sub is rejected by insert()'s event-level guard (same text and timing),
+    -- so the list holds only one sub.
+    local duplicate_subs = new_sub_list()
+    duplicate_subs.insert(Subtitle:from_text("Same line", 0, 2))
+    duplicate_subs.insert(Subtitle:from_text("Same line", 0.04, 2.04))
+    h.assert_equals(duplicate_subs.get_text(), "Same line")
+
+    local repeated_same_text_subs = new_sub_list()
+    repeated_same_text_subs.insert(Subtitle:from_text("Same line", 0, 1))
+    repeated_same_text_subs.insert(Subtitle:from_text("Same line", 3, 4))
+    h.assert_equals(repeated_same_text_subs.get_text(), "Same line\nSame line")
+
+    local repeated_event_subs = new_sub_list()
+    repeated_event_subs.insert(Subtitle:from_text("Yes", 0, 1))
+    repeated_event_subs.insert(Subtitle:from_text("No", 1, 2))
+    repeated_event_subs.insert(Subtitle:from_text("Yes", 2, 3))
+    h.assert_equals(repeated_event_subs.get_text(), "Yes\nNo\nYes")
+
+    -- A repeated line outside the adjacent suffix/prefix boundary must be kept.
+    -- The old global seen-set approach dropped the final "X" here.
+    local repeated_subs = new_sub_list()
+    repeated_subs.insert(Subtitle:from_text("X", 0, 1))
+    repeated_subs.insert(Subtitle:from_text("Y", 1, 2))
+    repeated_subs.insert(Subtitle:from_text("Y\nX", 2, 3))
+    h.assert_equals(repeated_subs.get_text(), "X\nY\nX")
+
+    local adjacent_overlap_subs = new_sub_list()
+    adjacent_overlap_subs.insert(Subtitle:from_text("Yes\nNo", 0, 2))
+    adjacent_overlap_subs.insert(Subtitle:from_text("No\nMaybe", 2, 4))
+    h.assert_equals(adjacent_overlap_subs.get_text(), "Yes\nNo\nMaybe")
+
+    local formatted_subs = new_sub_list()
+    formatted_subs.insert(Subtitle:from_text("First line\n\nSecond line", 0, 2))
+    h.assert_equals(formatted_subs.get_text(), "First line\n\nSecond line")
+
+    -- Lines repeated within a single sub are kept as-is:
+    -- dedup only applies at the boundary between consecutive subs.
+    local within_subs = new_sub_list()
+    within_subs.insert(Subtitle:from_text("A\nA", 0, 2))
+    h.assert_equals(within_subs.get_text(), "A\nA")
+
+    local crlf_subs = new_sub_list()
+    crlf_subs.insert(Subtitle:from_text("First line\r\nSecond line\rThird line", 0, 2))
+    h.assert_equals(crlf_subs.get_text(), "First line\nSecond line\nThird line")
+
+    -- A trailing newline must not introduce a spurious blank line.
+    local trailing_newline_subs = new_sub_list()
+    trailing_newline_subs.insert(Subtitle:from_text("First line\nSecond line\n", 0, 2))
+    h.assert_equals(trailing_newline_subs.get_text(), "First line\nSecond line")
+end
+
+local function test_get_n_text()
+    local first = Subtitle:from_text("First line", 0, 2)
+    local subs = new_sub_list()
+    subs.insert(first)
+    subs.insert(Subtitle:from_text("First line\nSecond line", 1, 3))
+    h.assert_equals(subs.get_n_text(first, 2), "First line\nSecond line")
+
+    local limited_subs = new_sub_list()
+    limited_subs.insert(Subtitle:from_text("First line", 0, 2))
+    limited_subs.insert(Subtitle:from_text("First line\nSecond line", 1, 3))
+    limited_subs.insert(Subtitle:from_text("Second line\nThird line", 2, 4))
+    h.assert_equals(limited_subs.get_n_text(first, 2), "First line\nSecond line")
+
+    -- Non-adjacent repeated lines are kept in get_n_text too.
+    local repeated_subs = new_sub_list()
+    repeated_subs.insert(Subtitle:from_text("Yes", 0, 1))
+    repeated_subs.insert(Subtitle:from_text("No", 1, 2))
+    repeated_subs.insert(Subtitle:from_text("Yes\nAgain", 2, 3))
+    h.assert_equals(repeated_subs.get_n_text(repeated_subs.get_subs_list()[1], 3), "Yes\nNo\nYes\nAgain")
+
+    -- A sub fully covered by the previous suffix still counts toward n_lines,
+    -- so end_sub (used for the card's end timing) advances past it.
+    local covered_subs = new_sub_list()
+    local container = Subtitle:from_text("A\nB", 0, 2)
+    covered_subs.insert(container)
+    covered_subs.insert(Subtitle:from_text("B", 1, 3))
+    covered_subs.insert(Subtitle:from_text("C", 2, 4))
+    local text, end_sub = covered_subs.get_n_text(container, 2)
+    h.assert_equals(text, "A\nB")
+    h.assert_equals(end_sub['end'], 3)
 end
 
 local function test_get_overlapping_text_uses_timing_and_removes_line_overlap()
@@ -289,7 +342,8 @@ local function run_tests()
     test_insert_preserves_sorted_order()
     test_get_time_returns_boundary_times()
     test_get_subs_list_returns_array_copy()
-    test_text_collection_removes_only_consecutive_line_overlap()
+    test_get_text()
+    test_get_n_text()
     test_get_overlapping_text_uses_timing_and_removes_line_overlap()
 end
 

--- a/mpvacious/subtitles/sub_list.lua
+++ b/mpvacious/subtitles/sub_list.lua
@@ -27,38 +27,53 @@ local new_sub_list = function()
         end
         return collector.get_all_as_string()
     end
-    local get_n_text = function(sub, n_lines)
+    --- Collect up to n_subs cues starting from start_sub and return them as one Subtitle
+    --- spanning from start_sub's start to the last collected cue's end. Collection stops
+    --- early at the first gap of MAX_SUB_GAP_SECONDS or more between consecutive cues.
+    --- Text is joined by the speech collector, which removes boundary line overlap
+    --- between consecutive time-overlapping cues.
+    local collect_n_subs = function(start_sub, n_subs)
         local collector = speech_collector.make_speech_collector()
-        local end_sub = sub
-        local n_subs = 0
-        for _, v in ipairs(subs_list) do
-            if v['start'] - end_sub['end'] >= MAX_SUB_GAP_SECONDS then
+        local end_sub = start_sub
+        local collected_count = 0
+        for _, sub in ipairs(subs_list) do
+            if sub['start'] - end_sub['end'] >= MAX_SUB_GAP_SECONDS then
                 break
             end
-            if not (v < sub) and n_subs < n_lines then
-                collector.append_sub(v)
-                end_sub = v
-                n_subs = n_subs + 1
+            if not (sub < start_sub) and collected_count < n_subs then
+                collector.append_sub(sub)
+                end_sub = sub
+                collected_count = collected_count + 1
             end
         end
-        return collector.get_all_as_string(), end_sub
+        return Subtitle:from_text(collector.get_all_as_string(), start_sub['start'], end_sub['end'])
     end
-    local get_overlapping_text = function(start_time, end_time)
+
+    --- Return the text of all subs overlapping the given time window, as one line.
+    --- Used to align secondary (translation) text with the primary text's time span:
+    --- primary and secondary cues have independent timings, so collecting secondary
+    --- text by line count or by the currently visible cue would misalign it with the
+    --- primary text. Cues merely touching a window edge are excluded.
+    --- Boundary overlap between consecutive cues is removed by the speech collector,
+    --- and the result is flattened to a single whitespace-collapsed, trimmed line.
+    --- `window` is a Subtitle, e.g. the combined primary Subtitle from collect_n_subs.
+    local get_overlapping_text = function(window)
         local collector = speech_collector.make_speech_collector()
         for _, sub in ipairs(subs_list) do
-            if sub['start'] < end_time and sub['end'] > start_time then
+            if sub:overlaps_in_time(window) then
                 collector.append_sub(sub)
             end
         end
         return collector.get_all_as_string():gsub('%s+', ' '):match('^%s*(.-)%s*$')
     end
+
     -- Event-level guard and expansion.
     -- The same sub event is offered repeatedly (on every sub change and on
     -- every collect call); exact duplicates (same text and timing) are skipped.
     -- An adjacent same-text event (overlapping or touching in time) expands
     -- the last recorded sub's end time.
     -- Text-overlap cleanup for multiline expansion is intentionally delayed
-    -- until get_text()/get_n_text(), where the selected output window is known.
+    -- until get_text()/collect_n_subs(), where the selected output window is known.
     local insert = function(sub)
         if sub == nil or h.is_empty(sub.text) then
             return false
@@ -91,7 +106,7 @@ local new_sub_list = function()
         get_subs_list = get_subs_list,
         get_time = get_time,
         get_text = get_text,
-        get_n_text = get_n_text,
+        collect_n_subs = collect_n_subs,
         get_overlapping_text = get_overlapping_text,
         insert = insert,
         is_empty = function()
@@ -289,25 +304,25 @@ local function test_get_text()
     h.assert_equals(trailing_newline_subs.get_text(), "First line\nSecond line")
 end
 
-local function test_get_n_text()
+local function test_collect_n_subs()
     local first = Subtitle:from_text("First line", 0, 2)
     local subs = new_sub_list()
     subs.insert(first)
     subs.insert(Subtitle:from_text("First line\nSecond line", 1, 3))
-    h.assert_equals(subs.get_n_text(first, 2), "First line\nSecond line")
+    h.assert_equals(subs.collect_n_subs(first, 2).text, "First line\nSecond line")
 
     local limited_subs = new_sub_list()
     limited_subs.insert(Subtitle:from_text("First line", 0, 2))
     limited_subs.insert(Subtitle:from_text("First line\nSecond line", 1, 3))
     limited_subs.insert(Subtitle:from_text("Second line\nThird line", 2, 4))
-    h.assert_equals(limited_subs.get_n_text(first, 2), "First line\nSecond line")
+    h.assert_equals(limited_subs.collect_n_subs(first, 2).text, "First line\nSecond line")
 
-    -- Non-adjacent repeated lines are kept in get_n_text too.
+    -- Non-adjacent repeated lines are kept in collect_n_subs too.
     local repeated_subs = new_sub_list()
     repeated_subs.insert(Subtitle:from_text("Yes", 0, 1))
     repeated_subs.insert(Subtitle:from_text("No", 1, 2))
     repeated_subs.insert(Subtitle:from_text("Yes\nAgain", 2, 3))
-    h.assert_equals(repeated_subs.get_n_text(repeated_subs.get_subs_list()[1], 3), "Yes\nNo\nYes\nAgain")
+    h.assert_equals(repeated_subs.collect_n_subs(repeated_subs.get_subs_list()[1], 3).text, "Yes\nNo\nYes\nAgain")
 
     -- A sub fully covered by the previous suffix still counts toward n_lines,
     -- so end_sub (used for the card's end timing) advances past it.
@@ -316,9 +331,10 @@ local function test_get_n_text()
     covered_subs.insert(container)
     covered_subs.insert(Subtitle:from_text("B", 1, 3))
     covered_subs.insert(Subtitle:from_text("C", 2, 4))
-    local text, end_sub = covered_subs.get_n_text(container, 2)
-    h.assert_equals(text, "A\nB")
-    h.assert_equals(end_sub['end'], 3)
+    local combined = covered_subs.collect_n_subs(container, 2)
+    h.assert_equals(combined["text"], "A\nB")
+    h.assert_equals(combined['start'], 0)
+    h.assert_equals(combined['end'], 3)
 end
 
 local function test_get_overlapping_text_uses_timing_and_removes_line_overlap()
@@ -327,7 +343,7 @@ local function test_get_overlapping_text_uses_timing_and_removes_line_overlap()
     subs.insert(Subtitle:from_text("First line", 1, 2))
     subs.insert(Subtitle:from_text("First line\nSecond line", 2, 3))
     subs.insert(Subtitle:from_text("After", 3, 4))
-    h.assert_equals(subs.get_overlapping_text(1, 3), "First line Second line")
+    h.assert_equals(subs.get_overlapping_text(Subtitle:from_text('', 1, 3)), "First line Second line")
 end
 
 local function run_tests()
@@ -343,7 +359,7 @@ local function run_tests()
     test_get_time_returns_boundary_times()
     test_get_subs_list_returns_array_copy()
     test_get_text()
-    test_get_n_text()
+    test_collect_n_subs()
     test_get_overlapping_text_uses_timing_and_removes_line_overlap()
 end
 

--- a/mpvacious/subtitles/sub_list.lua
+++ b/mpvacious/subtitles/sub_list.lua
@@ -14,30 +14,73 @@ local MAX_SUB_GAP_SECONDS = 20 -- stop joining lines separated by a longer gap
 local new_sub_list = function()
     local subs_list = {}
 
+    local append_text = function(speech, previous_sub, sub)
+        local lines = {}
+        local text = sub['text']:gsub('\r\n', '\n'):gsub('\r', '\n')
+        for line in (text .. '\n'):gmatch('(.-)\n') do
+            table.insert(lines, line)
+        end
+
+        local overlap = previous_sub and sub['start'] <= previous_sub['end'] and math.min(#speech, #lines) or 0
+        while overlap > 0 do
+            local matches = true
+            for i = 1, overlap do
+                if speech[#speech - overlap + i] ~= lines[i] then
+                    matches = false
+                    break
+                end
+            end
+            if matches then
+                break
+            end
+            overlap = overlap - 1
+        end
+        for i = overlap + 1, #lines do
+            table.insert(speech, lines[i])
+        end
+    end
+
     local get_time = function(position)
         local i = position == 'start' and 1 or #subs_list
         return subs_list[i][position]
     end
     local get_text = function()
         local speech = {}
+        local previous_sub = nil
         for _, sub in ipairs(subs_list) do
-            table.insert(speech, sub['text'])
+            append_text(speech, previous_sub, sub)
+            previous_sub = sub
         end
         return table.concat(speech, CONCAT_CHR)
     end
     local get_n_text = function(sub, n_lines)
         local speech = {}
         local end_sub = sub
+        local previous_sub = nil
+        local n_subs = 0
         for _, v in ipairs(subs_list) do
             if v['start'] - end_sub['end'] >= MAX_SUB_GAP_SECONDS then
                 break
             end
-            if v >= sub and #speech < n_lines then
-                table.insert(speech, v['text'])
+            if v >= sub and n_subs < n_lines then
+                append_text(speech, previous_sub, v)
+                previous_sub = v
                 end_sub = v
+                n_subs = n_subs + 1
             end
         end
         return table.concat(speech, CONCAT_CHR), end_sub
+    end
+    local get_overlapping_text = function(start_time, end_time)
+        local speech = {}
+        local previous_sub = nil
+        for _, sub in ipairs(subs_list) do
+            if sub['start'] < end_time and sub['end'] > start_time then
+                append_text(speech, previous_sub, sub)
+                previous_sub = sub
+            end
+        end
+        return table.concat(speech, CONCAT_CHR):gsub('%s+', ' '):match('^%s*(.-)%s*$')
     end
     local insert = function(sub)
         if sub == nil or h.is_empty(sub.text) then
@@ -71,6 +114,7 @@ local new_sub_list = function()
         get_time = get_time,
         get_text = get_text,
         get_n_text = get_n_text,
+        get_overlapping_text = get_overlapping_text,
         insert = insert,
         is_empty = function()
             return h.is_empty(subs_list)
@@ -208,6 +252,31 @@ local function test_get_subs_list_returns_array_copy()
     h.assert_equals(subs.get_subs_list()[1]['text'], "First line")
 end
 
+local function test_text_collection_removes_only_consecutive_line_overlap()
+    local growing = new_sub_list()
+    local first = Subtitle:from_text("First line", 0, 1)
+    growing.insert(first)
+    growing.insert(Subtitle:from_text("First line\nSecond line", 1, 2))
+    h.assert_equals(growing.get_text(), "First line\nSecond line")
+    h.assert_equals(growing.get_n_text(first, 2), "First line\nSecond line")
+
+    local subs = new_sub_list()
+    subs.insert(Subtitle:from_text("Yes", 0, 1))
+    subs.insert(Subtitle:from_text("No", 1, 2))
+    subs.insert(Subtitle:from_text("Yes\nAgain", 2, 3))
+    h.assert_equals(subs.get_text(), "Yes\nNo\nYes\nAgain")
+    h.assert_equals(subs.get_n_text(subs.get_subs_list()[1], 3), "Yes\nNo\nYes\nAgain")
+end
+
+local function test_get_overlapping_text_uses_timing_and_removes_line_overlap()
+    local subs = new_sub_list()
+    subs.insert(Subtitle:from_text("Before", 0, 1))
+    subs.insert(Subtitle:from_text("First line", 1, 2))
+    subs.insert(Subtitle:from_text("First line\nSecond line", 2, 3))
+    subs.insert(Subtitle:from_text("After", 3, 4))
+    h.assert_equals(subs.get_overlapping_text(1, 3), "First line Second line")
+end
+
 local function run_tests()
     test_insert_rejects_invalid_subs()
     test_insert_rejects_duplicate_event()
@@ -220,6 +289,8 @@ local function run_tests()
     test_insert_preserves_sorted_order()
     test_get_time_returns_boundary_times()
     test_get_subs_list_returns_array_copy()
+    test_text_collection_removes_only_consecutive_line_overlap()
+    test_get_overlapping_text_uses_timing_and_removes_line_overlap()
 end
 
 return {

--- a/mpvacious/subtitles/subtitle.lua
+++ b/mpvacious/subtitles/subtitle.lua
@@ -99,6 +99,7 @@ local function test_is_same_event()
 end
 
 local function test_eq_uses_same_event()
+    -- __eq delegates to is_same_event: same text and timing within tolerance.
     h.assert_equals(sub("A", 0, 2) == sub("A", 0.04, 2.04), true)
     h.assert_equals(sub("A", 0, 2) == sub("A", 3, 4), false)
 end

--- a/mpvacious/subtitles/subtitle.lua
+++ b/mpvacious/subtitles/subtitle.lua
@@ -62,6 +62,16 @@ function Subtitle:is_same_event(other)
     return self['text'] == other['text'] and is_near(self['start'], other['start']) and is_near(self['end'], other['end'])
 end
 
+--- Return true if this sub and other intersect in time. Touching boundaries do not count.
+function Subtitle:overlaps_in_time(other)
+    return self['start'] < other['end'] and self['end'] > other['start']
+end
+
+--- Return true if this sub and other intersect or merely touch in time.
+function Subtitle:overlaps_or_touches_in_time(other)
+    return self['start'] <= other['end'] and self['end'] >= other['start']
+end
+
 -- Same text and overlapping (or touching) in time. Strict: a real gap is a real gap.
 -- Forward-only: other must not start before self, so expanding never
 -- decreases start and the recorded list stays sorted.
@@ -104,6 +114,21 @@ local function test_eq_uses_same_event()
     h.assert_equals(sub("A", 0, 2) == sub("A", 3, 4), false)
 end
 
+local function test_time_overlap()
+    local cases = {
+        -- {first, second, overlaps, overlaps_or_touches}
+        { sub("A", 0, 2), sub("B", 1, 3), true, true },
+        { sub("A", 0, 1), sub("B", 1, 2), false, true },
+        { sub("A", 0, 1), sub("B", 1.01, 2), false, false },
+        { sub("A", 0, 5), sub("B", 1, 2), true, true },
+    }
+    for _, case in ipairs(cases) do
+        local first, second, overlaps, overlaps_or_touches = h.unpack(case)
+        h.assert_equals(first:overlaps_in_time(second), overlaps)
+        h.assert_equals(first:overlaps_or_touches_in_time(second), overlaps_or_touches)
+    end
+end
+
 local function test_can_expand_with()
     h.assert_equals(sub("A", 0, 1):can_expand_with(sub("A", 1, 2)), true)
     h.assert_equals(sub("A", 0, 2):can_expand_with(sub("A", 1, 3)), true)
@@ -121,6 +146,7 @@ end
 function Subtitle.run_tests()
     test_is_same_event()
     test_eq_uses_same_event()
+    test_time_overlap()
     test_can_expand_with()
     test_expand_end_time()
 end

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -11,59 +11,22 @@ Usage: luajit tests/run.lua
 
 require('tests.setup')
 
-------------------------------------------------------------
--- Run helpers tests
-------------------------------------------------------------
+local modules = {
+    'helpers',
+    'encoder.utils',
+    'config.utils',
+    'anki.note_exporter',
+    'subtitles.subtitle',
+    'subtitles.collector',
+    'subtitles.sub_list',
+}
 
-print("Running helpers tests...")
-local h = require('helpers')
-h.run_tests()
-print("helpers tests passed.")
-
-------------------------------------------------------------
--- Run encoder utility tests
-------------------------------------------------------------
-
-print("Running encoder utility tests...")
-local eutils = require('encoder.utils')
-eutils.run_tests()
-print("encoder utility tests passed.")
-
-------------------------------------------------------------
--- Run config utility tests
-------------------------------------------------------------
-
-print("Running config utility tests...")
-local cfg_utils = require('config.utils')
-cfg_utils.run_tests()
-print("config utility tests passed.")
-
-------------------------------------------------------------
--- Run note_exporter tests
-------------------------------------------------------------
-
-print("Running note_exporter tests...")
-local note_exporter = require('anki.note_exporter')
-note_exporter.run_tests()
-print("note_exporter tests passed.")
-
-------------------------------------------------------------
--- Run Subtitle tests
-------------------------------------------------------------
-
-print("Running subtitle tests...")
-local Subtitle = require('subtitles.subtitle')
-Subtitle.run_tests()
-print("subtitle tests passed.")
-
-------------------------------------------------------------
--- Run subtitle list tests
-------------------------------------------------------------
-
-print("Running subtitle list tests...")
-local sub_list = require('subtitles.sub_list')
-sub_list.run_tests()
-print("subtitle list tests passed.")
+for _, module_name in ipairs(modules) do
+    print(string.format("Running %s tests...", module_name))
+    local module = require(module_name)
+    module.run_tests()
+    print(string.format("%s tests passed.", module_name))
+end
 
 ------------------------------------------------------------
 


### PR DESCRIPTION
There's a problem when text get duplicated between two subtitles. Then I have to remove the duplicated text manually which is a pain. The other thing that annoys me is if I have Japanese cue with, let's say, 3 corresponding english cues, I have to manually select these overlapping english cues. This mr simply grabs all the corresponding english cues that fall into the range of the japanese cue.