### PR TITLE
fix: confirm mismatched note updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,9 @@ Advanced menu has the following options:
 * <kbd>f</kbd> - Increment number of cards to update.
   Only affects note updating, including quick card creation.
   The number of cards to update is reset to 1 upon updating a note.
+  If the requested recent cards don't all share the same sentence field as the
+  newest card, mpvacious asks whether to update all of them anyway. Press
+  <kbd>y</kbd> to continue or <kbd>n</kbd> to cancel; unanswered prompts time out.
 * <kbd>shift+f</kbd> - Decrement number of cards to update.
 
 * <kbd>c</kbd> - Interactive subtitle selection.

--- a/README.md
+++ b/README.md
@@ -409,6 +409,10 @@ Advanced menu has the following options:
 * <kbd>f</kbd> - Increment number of cards to update.
   Only affects note updating, including quick card creation.
   The number of cards to update is reset to 1 upon updating a note.
+  Before replacing a note whose sentence does not match the current subtitle,
+  mpvacious asks whether to continue. It also warns when the requested recent
+  notes do not all contain the same sentence. Select **Yes** to continue or
+  **No** to cancel; unanswered prompts time out after ten seconds.
 * <kbd>shift+f</kbd> - Decrement number of cards to update.
 
 * <kbd>c</kbd> - Interactive subtitle selection.

--- a/mpvacious/anki/note_exporter.lua
+++ b/mpvacious/anki/note_exporter.lua
@@ -80,6 +80,14 @@ local function make_exporter()
         mismatch_overlay.z = 1000
     end
 
+    local function clear_update_state()
+        self.subs_observer.clear()
+        self.quick_creation_opts:clear_options()
+        if self.subs_observer.menu and self.subs_observer.menu.update then
+            self.subs_observer.menu:update()
+        end
+    end
+
     local function clear_mismatch_confirmation()
         mp.remove_key_binding(confirm_mismatch_yes)
         mp.remove_key_binding(confirm_mismatch_no)
@@ -101,6 +109,7 @@ local function make_exporter()
 
         local function cancel_update()
             clear_mismatch_confirmation()
+            clear_update_state()
             h.notify("Card update cancelled.", "info", 2)
         end
 
@@ -474,8 +483,7 @@ local function make_exporter()
         snapshot.on_finish(create_files_countdown.decrease).run_async()
         audio.on_finish(create_files_countdown.decrease).run_async()
 
-        self.subs_observer.clear()
-        self.quick_creation_opts:clear_options()
+        clear_update_state()
         return pub
     end
 
@@ -707,6 +715,8 @@ local function make_exporter()
         local original_create_osd_overlay = mp.create_osd_overlay
         local confirmation_bindings = {}
         local confirmation_overlay = { update = function() return end, remove = function() return end }
+        local cleared_state = 0
+        local refreshed_menu = 0
         h.notify = function(message)
             notification = message
         end
@@ -733,8 +743,14 @@ local function make_exporter()
                         end
                     end,
                 },
-                { get_cards = function() return 5 end },
-                nil,
+                {
+                    get_cards = function() return 5 end,
+                    clear_options = function() cleared_state = cleared_state + 1 end,
+                },
+                {
+                    clear = function() cleared_state = cleared_state + 1 end,
+                    menu = { update = function() refreshed_menu = refreshed_menu + 1 end },
+                },
                 nil,
                 nil,
                 {
@@ -780,6 +796,8 @@ local function make_exporter()
         confirmation_bindings.n()
         h.assert_equals(updated, false)
         h.assert_equals(notification, "Card update cancelled.")
+        h.assert_equals(cleared_state, 2)
+        h.assert_equals(refreshed_menu, 1)
 
         sentences[1], sentences[2] = "target", "target"
         test_exporter.update_last_note(false)
@@ -799,6 +817,8 @@ local function make_exporter()
         local original_create_osd_overlay = mp.create_osd_overlay
         local confirmation_bindings = {}
         local confirmation_overlay = { update = function() return end, remove = function() return end }
+        local cleared_state = 0
+        local refreshed_menu = 0
         h.notify = function(message)
             notification = message
         end
@@ -810,6 +830,14 @@ local function make_exporter()
         end
         mp.create_osd_overlay = function()
             return confirmation_overlay
+        end
+
+        local function make_media_job()
+            local job = { filename = nil, run_async = function() return end }
+            job.on_finish = function()
+                return job
+            end
+            return job
         end
 
         local current_sub = {
@@ -824,8 +852,12 @@ local function make_exporter()
                     get_note_fields = function()
                         return { SentKanji = "そのメモ ちょっと<b>貸して</b>みろよ" }
                     end,
+                    get_media_dir_path = function() return "/tmp" end,
                 },
-                { get_lines = function() return nil end },
+                {
+                    get_lines = function() return nil end,
+                    clear_options = function() cleared_state = cleared_state + 1 end,
+                },
                 {
                     collect_from_current = function()
                         return current_sub
@@ -833,15 +865,23 @@ local function make_exporter()
                     clipboard_prepare = function(text)
                         return text
                     end,
+                    clear = function() cleared_state = cleared_state + 1 end,
+                    menu = { update = function() refreshed_menu = refreshed_menu + 1 end },
                 },
-                nil,
-                nil,
+                {
+                    set_output_dir = function() return end,
+                    snapshot = { create_job = make_media_job },
+                    audio = { create_job = make_media_job },
+                },
+                { set_output_dir = function() return end },
                 {
                     fail_if_not_ready = function() return end,
                     config = function()
                         return {
                             sentence_field = "SentKanji",
                             reload_config_before_card_creation = false,
+                            audio_padding = 0,
+                            miscinfo_enable = false,
                         }
                     end,
                 }
@@ -860,6 +900,13 @@ local function make_exporter()
 
         confirmation_bindings.ENTER()
         h.assert_equals(notification, "Card update cancelled.")
+        h.assert_equals(cleared_state, 2)
+        h.assert_equals(refreshed_menu, 1)
+
+        test_exporter.update_notes({ note_id }, true)
+        confirmation_bindings.y()
+        h.assert_equals(cleared_state, 4)
+        h.assert_equals(refreshed_menu, 2)
         h.notify = original_notify
         mp.add_forced_key_binding = original_add_key_binding
         mp.remove_key_binding = original_remove_key_binding

--- a/mpvacious/anki/note_exporter.lua
+++ b/mpvacious/anki/note_exporter.lua
@@ -55,12 +55,24 @@ local function join_field_content(new_text, old_text, cfg)
     return string.format("%s%s%s", old_text, cfg.separator, new_text)
 end
 
+local function sentences_are_related(new_text, old_text)
+    local normalized_new, normalized_old = normalize_field_content(new_text, old_text, { plaintext_compare = true })
+    if h.is_empty(normalized_new) or h.is_empty(normalized_old) then
+        return false
+    end
+    return h.is_substr(normalized_new, normalized_old) or h.is_substr(normalized_old, normalized_new)
+end
+
 local function make_exporter()
     local self = {}
     local pub = {}
     local pending_mismatch_timer = nil
     local confirm_mismatch_yes = "mpvacious-confirm-mismatched-notes-yes"
     local confirm_mismatch_no = "mpvacious-confirm-mismatched-notes-no"
+    local confirm_mismatch_enter = "mpvacious-confirm-mismatched-notes-enter"
+    local confirm_mismatch_left = "mpvacious-confirm-mismatched-notes-left"
+    local confirm_mismatch_right = "mpvacious-confirm-mismatched-notes-right"
+    local mismatch_selection = "no"
     local mismatch_overlay = mp.create_osd_overlay and mp.create_osd_overlay('ass-events')
     if mismatch_overlay then
         mismatch_overlay.res_x = 1280
@@ -71,6 +83,9 @@ local function make_exporter()
     local function clear_mismatch_confirmation()
         mp.remove_key_binding(confirm_mismatch_yes)
         mp.remove_key_binding(confirm_mismatch_no)
+        mp.remove_key_binding(confirm_mismatch_enter)
+        mp.remove_key_binding(confirm_mismatch_left)
+        mp.remove_key_binding(confirm_mismatch_right)
         if mismatch_overlay then
             mismatch_overlay:remove()
         end
@@ -78,9 +93,10 @@ local function make_exporter()
             pending_mismatch_timer:kill()
             pending_mismatch_timer = nil
         end
+        mismatch_selection = "no"
     end
 
-    local function confirm_mismatched_notes(note_ids, overwrite, related_count)
+    local function confirm_mismatched_notes(note_ids, warning, proceed_with_update)
         clear_mismatch_confirmation()
 
         local function cancel_update()
@@ -88,25 +104,23 @@ local function make_exporter()
             h.notify("Card update cancelled.", "info", 2)
         end
 
-        local function proceed_with_update()
+        local function confirm_update()
             clear_mismatch_confirmation()
-            pub.update_notes(note_ids, overwrite)
+            proceed_with_update()
         end
 
-        mp.add_forced_key_binding("y", confirm_mismatch_yes, proceed_with_update)
-        mp.add_forced_key_binding("n", confirm_mismatch_no, cancel_update)
-        if mp.add_timeout then
-            pending_mismatch_timer = mp.add_timeout(10, cancel_update)
+        local question
+        if #note_ids == 1 then
+            question = "Update this note anyway?"
+        else
+            question = string.format("Update all %i anyway?", #note_ids)
         end
-        local warning = string.format(
-                "Only the newest %i of %i notes share %s.",
-                related_count,
-                #note_ids,
-                self.config.sentence_field
-        )
-        msg.warn(string.format("%s Update all %i anyway? [y] Yes [n] No", warning, #note_ids))
-        if mismatch_overlay then
-            mismatch_overlay.data = OSD:new()
+
+        local function update_confirmation_overlay()
+            if not mismatch_overlay then
+                return
+            end
+            local osd = OSD:new()
                     :new_layer()
                     :align(5)
                     :pos(640, 360)
@@ -116,13 +130,52 @@ local function make_exporter()
                     :newline()
                     :text(warning)
                     :newline()
-                    :text(string.format("Update all %i anyway?", #note_ids))
+                    :text(question)
                     :newline()
-                    :item("[y] Yes")
-                    :text("      ")
-                    :item("[n] No")
-                    :get_text()
+            if mismatch_selection == "yes" then
+                osd:blue("[y] Yes")
+            else
+                osd:item("[y] Yes")
+            end
+            osd:text("      ")
+            if mismatch_selection == "no" then
+                osd:blue("[n] No")
+            else
+                osd:item("[n] No")
+            end
+            osd:newline():italics("←/→ select      Enter confirm")
+            mismatch_overlay.data = osd:get_text()
             mismatch_overlay:update()
+        end
+
+        local function select_option(option)
+            mismatch_selection = option
+            update_confirmation_overlay()
+        end
+
+        local function confirm_selection()
+            if mismatch_selection == "yes" then
+                confirm_update()
+            else
+                cancel_update()
+            end
+        end
+
+        mp.add_forced_key_binding("y", confirm_mismatch_yes, confirm_update)
+        mp.add_forced_key_binding("n", confirm_mismatch_no, cancel_update)
+        mp.add_forced_key_binding("ENTER", confirm_mismatch_enter, confirm_selection)
+        mp.add_forced_key_binding("left", confirm_mismatch_left, function()
+            select_option("yes")
+        end)
+        mp.add_forced_key_binding("right", confirm_mismatch_right, function()
+            select_option("no")
+        end)
+        if mp.add_timeout then
+            pending_mismatch_timer = mp.add_timeout(10, cancel_update)
+        end
+        msg.warn(string.format("%s %s [y] Yes [n] No", warning, question))
+        if mismatch_overlay then
+            update_confirmation_overlay()
         end
     end
 
@@ -352,7 +405,7 @@ local function make_exporter()
         end
     end
 
-    function pub.update_notes(note_ids, overwrite)
+    local function collect_update_subtitle()
         local sub
         local n_lines = self.quick_creation_opts:get_lines()
         if n_lines then
@@ -360,10 +413,46 @@ local function make_exporter()
         else
             sub = self.subs_observer.collect_from_current()
         end
+        return sub
+    end
 
-        if not sub:is_valid() then
-            return h.notify("Nothing to export. Have you set the timings?", "warn", 2)
+    local function current_subtitle_mismatch(note_ids, sub)
+        if h.is_empty(sub['text']) then
+            return nil
         end
+
+        local current_sentence = prepare_for_exporting(sub['text'])
+        local comparable_count = 0
+        local related_count = 0
+        for _, note_id in ipairs(note_ids) do
+            local fields = self.ankiconnect.get_note_fields(note_id) or {}
+            local stored_sentence = fields[self.config.sentence_field] or ""
+            if not h.is_empty(h.normalize_subtitle_text(stored_sentence)) then
+                comparable_count = comparable_count + 1
+                if sentences_are_related(current_sentence, stored_sentence) then
+                    related_count = related_count + 1
+                end
+            end
+        end
+
+        if comparable_count == 0 or related_count == comparable_count then
+            return nil
+        elseif #note_ids == 1 then
+            return string.format(
+                    "The target note's %s does not match the current subtitle.",
+                    self.config.sentence_field
+            )
+        else
+            return string.format(
+                    "Only %i of %i target notes have %s matching the current subtitle.",
+                    related_count,
+                    comparable_count,
+                    self.config.sentence_field
+            )
+        end
+    end
+
+    local function perform_update(note_ids, overwrite, sub)
 
         if h.is_empty(sub['text']) then
             -- In this case, don't modify whatever existing text there is and just
@@ -388,6 +477,24 @@ local function make_exporter()
         self.subs_observer.clear()
         self.quick_creation_opts:clear_options()
         return pub
+    end
+
+    function pub.update_notes(note_ids, overwrite)
+        local sub = collect_update_subtitle()
+
+        if not sub:is_valid() then
+            return h.notify("Nothing to export. Have you set the timings?", "warn", 2)
+        end
+
+        local warning = current_subtitle_mismatch(note_ids, sub)
+        if warning then
+            confirm_mismatched_notes(note_ids, warning, function()
+                perform_update(note_ids, overwrite, sub)
+            end)
+            return pub
+        end
+
+        return perform_update(note_ids, overwrite, sub)
     end
 
     function pub.maybe_reload_config()
@@ -465,7 +572,15 @@ local function make_exporter()
             end
 
             if related_count < n_cards then
-                confirm_mismatched_notes(last_note_ids, overwrite, related_count)
+                local warning = string.format(
+                        "Only the newest %i of %i notes share %s.",
+                        related_count,
+                        #last_note_ids,
+                        self.config.sentence_field
+                )
+                confirm_mismatched_notes(last_note_ids, warning, function()
+                    pub.update_notes(last_note_ids, overwrite)
+                end)
                 return pub
             end
         end
@@ -642,7 +757,21 @@ local function make_exporter()
         h.assert_equals(h.is_substr(confirmation_overlay.data, "Update all 5 anyway?"), true)
         h.assert_equals(type(confirmation_bindings.y), "function")
         h.assert_equals(type(confirmation_bindings.n), "function")
+        h.assert_equals(type(confirmation_bindings.ENTER), "function")
+        h.assert_equals(type(confirmation_bindings.left), "function")
+        h.assert_equals(type(confirmation_bindings.right), "function")
+        h.assert_equals(h.is_substr(confirmation_overlay.data, OSD:new():blue("[n] No"):get_text()), true)
 
+        confirmation_bindings.left()
+        h.assert_equals(h.is_substr(confirmation_overlay.data, OSD:new():blue("[y] Yes"):get_text()), true)
+        confirmation_bindings.right()
+        h.assert_equals(h.is_substr(confirmation_overlay.data, OSD:new():blue("[n] No"):get_text()), true)
+        confirmation_bindings.left()
+        confirmation_bindings.ENTER()
+        h.assert_equals(updated, true)
+
+        updated = false
+        test_exporter.update_last_note(false)
         confirmation_bindings.y()
         h.assert_equals(updated, true)
 
@@ -655,6 +784,82 @@ local function make_exporter()
         sentences[1], sentences[2] = "target", "target"
         test_exporter.update_last_note(false)
         h.assert_equals(updated, true)
+        h.notify = original_notify
+        mp.add_forced_key_binding = original_add_key_binding
+        mp.remove_key_binding = original_remove_key_binding
+        mp.create_osd_overlay = original_create_osd_overlay
+    end
+
+    local function test_update_notes_confirms_unrelated_single_note()
+        local note_id = os.time() * 1000
+        local notification = nil
+        local original_notify = h.notify
+        local original_add_key_binding = mp.add_forced_key_binding
+        local original_remove_key_binding = mp.remove_key_binding
+        local original_create_osd_overlay = mp.create_osd_overlay
+        local confirmation_bindings = {}
+        local confirmation_overlay = { update = function() return end, remove = function() return end }
+        h.notify = function(message)
+            notification = message
+        end
+        mp.add_forced_key_binding = function(key, _, fn)
+            confirmation_bindings[key] = fn
+        end
+        mp.remove_key_binding = function()
+            return
+        end
+        mp.create_osd_overlay = function()
+            return confirmation_overlay
+        end
+
+        local current_sub = {
+            text = "無視された 小学生女子に シカトされた",
+            secondary = "I was ignored by an elementary school girl.",
+            is_valid = function()
+                return true
+            end,
+        }
+        local test_exporter = make_exporter().init(
+                {
+                    get_note_fields = function()
+                        return { SentKanji = "そのメモ ちょっと<b>貸して</b>みろよ" }
+                    end,
+                },
+                { get_lines = function() return nil end },
+                {
+                    collect_from_current = function()
+                        return current_sub
+                    end,
+                    clipboard_prepare = function(text)
+                        return text
+                    end,
+                },
+                nil,
+                nil,
+                {
+                    fail_if_not_ready = function() return end,
+                    config = function()
+                        return {
+                            sentence_field = "SentKanji",
+                            reload_config_before_card_creation = false,
+                        }
+                    end,
+                }
+        )
+
+        test_exporter.update_notes({ note_id }, true)
+        h.assert_equals(
+                h.is_substr(confirmation_overlay.data, "The target note's SentKanji does not match the current subtitle."),
+                true
+        )
+        h.assert_equals(h.is_substr(confirmation_overlay.data, "Update this note anyway?"), true)
+        h.assert_equals(type(confirmation_bindings.y), "function")
+        h.assert_equals(type(confirmation_bindings.n), "function")
+        h.assert_equals(type(confirmation_bindings.ENTER), "function")
+        h.assert_equals(h.is_substr(confirmation_overlay.data, OSD:new():blue("[n] No"):get_text()), true)
+
+        confirmation_bindings.ENTER()
+        h.assert_equals(notification, "Card update cancelled.")
         h.notify = original_notify
         mp.add_forced_key_binding = original_add_key_binding
         mp.remove_key_binding = original_remove_key_binding
@@ -682,6 +887,7 @@ local function make_exporter()
         test_join_fields_duplicates()
         test_make_new_note_data()
         test_update_last_note_confirms_unrelated_notes()
+        test_update_notes_confirms_unrelated_single_note()
         return pub
     end
 
@@ -692,6 +898,9 @@ local function run_tests(test_exporter)
     -- Test join_field_content
     h.assert_equals(join_field_content("ヤツらの声に現実味が…", "あの遠さはヤツらの声に現実味が…"), "あの遠さはヤツらの声に現実味が…")
     h.assert_equals(join_field_content("あの遠さはヤツらの声に現実味が…", "ヤツらの声に現実味が…"), "あの遠さはヤツらの声に現実味が…")
+    h.assert_equals(sentences_are_related("<b>target</b>", "target"), true)
+    h.assert_equals(sentences_are_related("a longer target sentence", "target"), true)
+    h.assert_equals(sentences_are_related("unrelated", "target"), false)
 
     local test_cfg_mgr = {
         fail_if_not_ready = function()

--- a/mpvacious/anki/note_exporter.lua
+++ b/mpvacious/anki/note_exporter.lua
@@ -4,10 +4,10 @@ License: GNU GPL, version 3 or later; http://www.gnu.org/licenses/gpl.html
 ]]
 
 local mp = require('mp')
+local input = require('mp.input')
 local msg = require('mp.msg')
 local h = require('helpers')
 local dec_counter = require('utils.dec_counter')
-local OSD = require('menu.osd_styler')
 
 --- Instead of comparing fields literally, normalize them to match different representations.
 local function normalize_field_content(new_text, old_text, cfg)
@@ -66,19 +66,7 @@ end
 local function make_exporter()
     local self = {}
     local pub = {}
-    local pending_mismatch_timer = nil
-    local confirm_mismatch_yes = "mpvacious-confirm-mismatched-notes-yes"
-    local confirm_mismatch_no = "mpvacious-confirm-mismatched-notes-no"
-    local confirm_mismatch_enter = "mpvacious-confirm-mismatched-notes-enter"
-    local confirm_mismatch_left = "mpvacious-confirm-mismatched-notes-left"
-    local confirm_mismatch_right = "mpvacious-confirm-mismatched-notes-right"
-    local mismatch_selection = "no"
-    local mismatch_overlay = mp.create_osd_overlay and mp.create_osd_overlay('ass-events')
-    if mismatch_overlay then
-        mismatch_overlay.res_x = 1280
-        mismatch_overlay.res_y = 720
-        mismatch_overlay.z = 1000
-    end
+    local active_mismatch_confirmation = nil
 
     local function clear_update_state()
         self.subs_observer.clear()
@@ -89,103 +77,61 @@ local function make_exporter()
     end
 
     local function clear_mismatch_confirmation()
-        mp.remove_key_binding(confirm_mismatch_yes)
-        mp.remove_key_binding(confirm_mismatch_no)
-        mp.remove_key_binding(confirm_mismatch_enter)
-        mp.remove_key_binding(confirm_mismatch_left)
-        mp.remove_key_binding(confirm_mismatch_right)
-        if mismatch_overlay then
-            mismatch_overlay:remove()
+        if active_mismatch_confirmation then
+            active_mismatch_confirmation.resolved = true
+            if active_mismatch_confirmation.timer then
+                active_mismatch_confirmation.timer:kill()
+            end
+            active_mismatch_confirmation = nil
+            input.terminate()
         end
-        if pending_mismatch_timer then
-            pending_mismatch_timer:kill()
-            pending_mismatch_timer = nil
-        end
-        mismatch_selection = "no"
     end
 
     local function confirm_mismatched_notes(note_ids, warning, proceed_with_update)
         clear_mismatch_confirmation()
+        local confirmation = { resolved = false, timer = nil }
+        active_mismatch_confirmation = confirmation
 
-        local function cancel_update()
-            clear_mismatch_confirmation()
-            clear_update_state()
-            h.notify("Card update cancelled.", "info", 2)
-        end
-
-        local function confirm_update()
-            clear_mismatch_confirmation()
-            proceed_with_update()
-        end
-
-        local question
-        if #note_ids == 1 then
-            question = "Update this note anyway?"
-        else
-            question = string.format("Update all %i anyway?", #note_ids)
-        end
-
-        local function update_confirmation_overlay()
-            if not mismatch_overlay then
+        local function finish(confirmed)
+            if confirmation.resolved then
                 return
             end
-            local osd = OSD:new()
-                    :new_layer()
-                    :align(5)
-                    :pos(640, 360)
-                    :border(3)
-                    :fsize(32)
-                    :red("Warning")
-                    :newline()
-                    :text(warning)
-                    :newline()
-                    :text(question)
-                    :newline()
-            if mismatch_selection == "yes" then
-                osd:blue("[y] Yes")
-            else
-                osd:item("[y] Yes")
+            confirmation.resolved = true
+            if confirmation.timer then
+                confirmation.timer:kill()
             end
-            osd:text("      ")
-            if mismatch_selection == "no" then
-                osd:blue("[n] No")
-            else
-                osd:item("[n] No")
+            if active_mismatch_confirmation == confirmation then
+                active_mismatch_confirmation = nil
             end
-            osd:newline():italics("←/→ select      Enter confirm")
-            mismatch_overlay.data = osd:get_text()
-            mismatch_overlay:update()
-        end
-
-        local function select_option(option)
-            mismatch_selection = option
-            update_confirmation_overlay()
-        end
-
-        local function confirm_selection()
-            if mismatch_selection == "yes" then
-                confirm_update()
+            input.terminate()
+            if confirmed then
+                proceed_with_update()
             else
-                cancel_update()
+                clear_update_state()
+                h.notify("Card update cancelled.", "info", 2)
             end
         end
 
-        mp.add_forced_key_binding("y", confirm_mismatch_yes, confirm_update)
-        mp.add_forced_key_binding("n", confirm_mismatch_no, cancel_update)
-        mp.add_forced_key_binding("ENTER", confirm_mismatch_enter, confirm_selection)
-        mp.add_forced_key_binding("left", confirm_mismatch_left, function()
-            select_option("yes")
-        end)
-        mp.add_forced_key_binding("right", confirm_mismatch_right, function()
-            select_option("no")
-        end)
+        local question = #note_ids == 1
+                and "Update this note anyway?"
+                or string.format("Update all %i anyway?", #note_ids)
+        input.select({
+            prompt = string.format("Warning: %s mismatch. %s", self.config.sentence_field, question),
+            items = { "Yes", "No" },
+            default_item = 2,
+            submit = function(index)
+                finish(index == 1)
+            end,
+            closed = function()
+                finish(false)
+            end,
+        })
         if mp.add_timeout then
-            pending_mismatch_timer = mp.add_timeout(10, cancel_update)
+            confirmation.timer = mp.add_timeout(10, function()
+                finish(false)
+            end)
         end
-        msg.warn(string.format("%s %s [y] Yes [n] No", warning, question))
-        if mismatch_overlay then
-            update_confirmation_overlay()
-        end
+        msg.warn(string.format("%s %s", warning, question))
     end
 
     local substitute_fmt = (function()
@@ -487,16 +433,20 @@ local function make_exporter()
         return pub
     end
 
-    function pub.update_notes(note_ids, overwrite)
+    function pub.update_notes(note_ids, overwrite, warnings)
         local sub = collect_update_subtitle()
 
         if not sub:is_valid() then
             return h.notify("Nothing to export. Have you set the timings?", "warn", 2)
         end
 
-        local warning = current_subtitle_mismatch(note_ids, sub)
-        if warning then
-            confirm_mismatched_notes(note_ids, warning, function()
+        warnings = warnings or {}
+        local subtitle_warning = current_subtitle_mismatch(note_ids, sub)
+        if subtitle_warning then
+            table.insert(warnings, subtitle_warning)
+        end
+        if #warnings > 0 then
+            confirm_mismatched_notes(note_ids, table.concat(warnings, "\n"), function()
                 perform_update(note_ids, overwrite, sub)
             end)
             return pub
@@ -586,9 +536,7 @@ local function make_exporter()
                         #last_note_ids,
                         self.config.sentence_field
                 )
-                confirm_mismatched_notes(last_note_ids, warning, function()
-                    pub.update_notes(last_note_ids, overwrite)
-                end)
+                pub.update_notes(last_note_ids, overwrite, { warning })
                 return pub
             end
         end
@@ -703,34 +651,8 @@ local function make_exporter()
         h.assert_equals(make_new_note_data(old_note, new_note, { overwrite = false, disable_forvo = true }).SentKanji, expected.SentKanji)
     end
 
-    local function test_update_last_note_confirms_unrelated_notes()
-        local now_ms = os.time() * 1000
-        local note_ids = { now_ms - 5, now_ms - 4, now_ms - 3, now_ms - 2, now_ms - 1 }
-        local sentences = { "unrelated one", "unrelated two", "target", "<b>target</b>", "target" }
-        local updated = false
-        local notification = nil
-        local original_notify = h.notify
-        local original_add_key_binding = mp.add_forced_key_binding
-        local original_remove_key_binding = mp.remove_key_binding
-        local original_create_osd_overlay = mp.create_osd_overlay
-        local confirmation_bindings = {}
-        local confirmation_overlay = { update = function() return end, remove = function() return end }
-        local cleared_state = 0
-        local refreshed_menu = 0
-        h.notify = function(message)
-            notification = message
-        end
-        mp.add_forced_key_binding = function(key, _, fn)
-            confirmation_bindings[key] = fn
-        end
-        mp.remove_key_binding = function()
-            return
-        end
-        mp.create_osd_overlay = function()
-            return confirmation_overlay
-        end
-
-        local test_exporter = make_exporter().init(
+    local function make_recent_notes_test_exporter(note_ids, sentences)
+        return make_exporter().init(
                 {
                     get_last_note_ids = function()
                         return note_ids
@@ -745,11 +667,8 @@ local function make_exporter()
                 },
                 {
                     get_cards = function() return 5 end,
-                    clear_options = function() cleared_state = cleared_state + 1 end,
                 },
                 {
-                    clear = function() cleared_state = cleared_state + 1 end,
-                    menu = { update = function() refreshed_menu = refreshed_menu + 1 end },
                 },
                 nil,
                 nil,
@@ -763,83 +682,73 @@ local function make_exporter()
                     end,
                 }
         )
-        test_exporter.update_notes = function()
-            updated = true
-        end
-
-        test_exporter.update_last_note(false)
-        h.assert_equals(updated, false)
-        h.assert_equals(h.is_substr(confirmation_overlay.data, "Only the newest 3 of 5 notes share SentKanji."), true)
-        h.assert_equals(h.is_substr(confirmation_overlay.data, "Update all 5 anyway?"), true)
-        h.assert_equals(type(confirmation_bindings.y), "function")
-        h.assert_equals(type(confirmation_bindings.n), "function")
-        h.assert_equals(type(confirmation_bindings.ENTER), "function")
-        h.assert_equals(type(confirmation_bindings.left), "function")
-        h.assert_equals(type(confirmation_bindings.right), "function")
-        h.assert_equals(h.is_substr(confirmation_overlay.data, OSD:new():blue("[n] No"):get_text()), true)
-
-        confirmation_bindings.left()
-        h.assert_equals(h.is_substr(confirmation_overlay.data, OSD:new():blue("[y] Yes"):get_text()), true)
-        confirmation_bindings.right()
-        h.assert_equals(h.is_substr(confirmation_overlay.data, OSD:new():blue("[n] No"):get_text()), true)
-        confirmation_bindings.left()
-        confirmation_bindings.ENTER()
-        h.assert_equals(updated, true)
-
-        updated = false
-        test_exporter.update_last_note(false)
-        confirmation_bindings.y()
-        h.assert_equals(updated, true)
-
-        updated = false
-        test_exporter.update_last_note(false)
-        confirmation_bindings.n()
-        h.assert_equals(updated, false)
-        h.assert_equals(notification, "Card update cancelled.")
-        h.assert_equals(cleared_state, 2)
-        h.assert_equals(refreshed_menu, 1)
-
-        sentences[1], sentences[2] = "target", "target"
-        test_exporter.update_last_note(false)
-        h.assert_equals(updated, true)
-        h.notify = original_notify
-        mp.add_forced_key_binding = original_add_key_binding
-        mp.remove_key_binding = original_remove_key_binding
-        mp.create_osd_overlay = original_create_osd_overlay
     end
 
-    local function test_update_notes_confirms_unrelated_single_note()
-        local note_id = os.time() * 1000
-        local notification = nil
-        local original_notify = h.notify
-        local original_add_key_binding = mp.add_forced_key_binding
-        local original_remove_key_binding = mp.remove_key_binding
-        local original_create_osd_overlay = mp.create_osd_overlay
-        local confirmation_bindings = {}
-        local confirmation_overlay = { update = function() return end, remove = function() return end }
-        local cleared_state = 0
-        local refreshed_menu = 0
-        h.notify = function(message)
-            notification = message
-        end
-        mp.add_forced_key_binding = function(key, _, fn)
-            confirmation_bindings[key] = fn
-        end
-        mp.remove_key_binding = function()
-            return
-        end
-        mp.create_osd_overlay = function()
-            return confirmation_overlay
+    local function test_update_last_note_passes_group_warning_to_shared_confirmation()
+        local now_ms = os.time() * 1000
+        local note_ids = { now_ms - 5, now_ms - 4, now_ms - 3, now_ms - 2, now_ms - 1 }
+        local sentences = { "unrelated one", "unrelated two", "target", "<b>target</b>", "target" }
+        local passed_warnings = nil
+        local test_exporter = make_recent_notes_test_exporter(note_ids, sentences)
+        test_exporter.update_notes = function(_, _, warnings)
+            passed_warnings = warnings
         end
 
-        local function make_media_job()
-            local job = { filename = nil, run_async = function() return end }
-            job.on_finish = function()
-                return job
-            end
+        test_exporter.update_last_note(false)
+        h.assert_equals(#passed_warnings, 1)
+        h.assert_equals(passed_warnings[1], "Only the newest 3 of 5 notes share SentKanji.")
+
+        sentences[1], sentences[2] = "target", "target"
+        passed_warnings = nil
+        test_exporter.update_last_note(false)
+        h.assert_equals(passed_warnings, nil)
+    end
+
+    local function install_confirmation_test_stubs(state)
+        local originals = {
+            notify = h.notify,
+            warn = msg.warn,
+            select = input.select,
+            terminate = input.terminate,
+            add_timeout = mp.add_timeout,
+        }
+        h.notify = function(message)
+            state.notification = message
+        end
+        msg.warn = function(message)
+            state.warning_log = message
+        end
+        input.select = function(options)
+            state.options = options
+        end
+        input.terminate = function()
+            state.terminated = state.terminated + 1
+        end
+        mp.add_timeout = function(_, callback)
+            state.timeout = callback
+            return { kill = function() state.timer_kills = state.timer_kills + 1 end }
+        end
+        return function()
+            h.notify = originals.notify
+            msg.warn = originals.warn
+            input.select = originals.select
+            input.terminate = originals.terminate
+            mp.add_timeout = originals.add_timeout
+        end
+    end
+
+    local function make_confirmation_media_job(state)
+        local job = { filename = nil }
+        job.on_finish = function()
             return job
         end
+        job.run_async = function()
+            state.media_jobs = state.media_jobs + 1
+        end
+        return job
+    end
 
+    local function make_confirmation_test_exporter(state)
         local current_sub = {
             text = "無視された 小学生女子に シカトされた",
             secondary = "I was ignored by an elementary school girl.",
@@ -856,7 +765,7 @@ local function make_exporter()
                 },
                 {
                     get_lines = function() return nil end,
-                    clear_options = function() cleared_state = cleared_state + 1 end,
+                    clear_options = function() state.cleared = state.cleared + 1 end,
                 },
                 {
                     collect_from_current = function()
@@ -865,13 +774,13 @@ local function make_exporter()
                     clipboard_prepare = function(text)
                         return text
                     end,
-                    clear = function() cleared_state = cleared_state + 1 end,
-                    menu = { update = function() refreshed_menu = refreshed_menu + 1 end },
+                    clear = function() state.cleared = state.cleared + 1 end,
+                    menu = { update = function() state.menu_updates = state.menu_updates + 1 end },
                 },
                 {
                     set_output_dir = function() return end,
-                    snapshot = { create_job = make_media_job },
-                    audio = { create_job = make_media_job },
+                    snapshot = { create_job = function() return make_confirmation_media_job(state) end },
+                    audio = { create_job = function() return make_confirmation_media_job(state) end },
                 },
                 { set_output_dir = function() return end },
                 {
@@ -886,31 +795,73 @@ local function make_exporter()
                     end,
                 }
         )
+        return test_exporter
+    end
 
-        test_exporter.update_notes({ note_id }, true)
+    local function make_confirmation_test()
+        local state = {
+            cleared = 0,
+            media_jobs = 0,
+            menu_updates = 0,
+            terminated = 0,
+            timer_kills = 0,
+        }
+        local restore = install_confirmation_test_stubs(state)
+        return make_confirmation_test_exporter(state), state, restore
+    end
+
+    local function test_update_notes_combines_mismatch_warnings()
+        local test_exporter, state, restore = make_confirmation_test()
+        local note_ids = { os.time() * 1000, os.time() * 1000 + 1 }
+        local group_warning = "The target notes do not all share SentKanji."
+        test_exporter.update_notes(note_ids, true, { group_warning })
+        h.assert_equals(h.is_substr(state.warning_log, group_warning), true)
         h.assert_equals(
-                h.is_substr(confirmation_overlay.data, "The target note's SentKanji does not match the current subtitle."),
+                h.is_substr(state.warning_log, "Only 0 of 2 target notes have SentKanji matching the current subtitle."),
                 true
         )
-        h.assert_equals(h.is_substr(confirmation_overlay.data, "Update this note anyway?"), true)
-        h.assert_equals(type(confirmation_bindings.y), "function")
-        h.assert_equals(type(confirmation_bindings.n), "function")
-        h.assert_equals(type(confirmation_bindings.ENTER), "function")
-        h.assert_equals(h.is_substr(confirmation_overlay.data, OSD:new():blue("[n] No"):get_text()), true)
+        local _, question_count = state.options.prompt:gsub("Update all 2 anyway%?", "")
+        h.assert_equals(question_count, 1)
+        h.assert_equals(state.options.prompt:find("\n"), nil)
+        restore()
+    end
 
-        confirmation_bindings.ENTER()
-        h.assert_equals(notification, "Card update cancelled.")
-        h.assert_equals(cleared_state, 2)
-        h.assert_equals(refreshed_menu, 1)
+    local function test_confirmation_defaults_to_no_and_cancels()
+        local test_exporter, state, restore = make_confirmation_test()
+        test_exporter.update_notes({ os.time() * 1000 }, true)
+        h.assert_equals(state.options.default_item, 2)
+        h.assert_equals(state.options.items[2], "No")
+        state.options.submit(2)
+        h.assert_equals(state.notification, "Card update cancelled.")
+        h.assert_equals(state.cleared, 2)
+        h.assert_equals(state.menu_updates, 1)
+        restore()
+    end
 
-        test_exporter.update_notes({ note_id }, true)
-        confirmation_bindings.y()
-        h.assert_equals(cleared_state, 4)
-        h.assert_equals(refreshed_menu, 2)
-        h.notify = original_notify
-        mp.add_forced_key_binding = original_add_key_binding
-        mp.remove_key_binding = original_remove_key_binding
-        mp.create_osd_overlay = original_create_osd_overlay
+    local function test_confirmation_waits_for_yes_before_creating_media()
+        local test_exporter, state, restore = make_confirmation_test()
+        test_exporter.update_notes({ os.time() * 1000 }, true)
+        h.assert_equals(state.media_jobs, 0)
+        state.options.submit(1)
+        h.assert_equals(state.media_jobs, 2)
+        h.assert_equals(state.cleared, 2)
+        state.options.closed()
+        h.assert_equals(state.media_jobs, 2)
+        h.assert_equals(state.cleared, 2)
+        restore()
+    end
+
+    local function test_confirmation_close_and_timeout_cancel()
+        local test_exporter, state, restore = make_confirmation_test()
+        test_exporter.update_notes({ os.time() * 1000 }, true)
+        state.options.closed()
+        h.assert_equals(state.notification, "Card update cancelled.")
+
+        test_exporter.update_notes({ os.time() * 1000 }, true)
+        state.timeout()
+        h.assert_equals(state.cleared, 4)
+        h.assert_equals(state.media_jobs, 0)
+        restore()
     end
 
     local function test_html_escaping()
@@ -933,8 +884,11 @@ local function make_exporter()
         test_html_escaping()
         test_join_fields_duplicates()
         test_make_new_note_data()
-        test_update_last_note_confirms_unrelated_notes()
-        test_update_notes_confirms_unrelated_single_note()
+        test_update_last_note_passes_group_warning_to_shared_confirmation()
+        test_update_notes_combines_mismatch_warnings()
+        test_confirmation_defaults_to_no_and_cancels()
+        test_confirmation_waits_for_yes_before_creating_media()
+        test_confirmation_close_and_timeout_cancel()
         return pub
     end
 

--- a/mpvacious/anki/note_exporter.lua
+++ b/mpvacious/anki/note_exporter.lua
@@ -4,8 +4,10 @@ License: GNU GPL, version 3 or later; http://www.gnu.org/licenses/gpl.html
 ]]
 
 local mp = require('mp')
+local msg = require('mp.msg')
 local h = require('helpers')
 local dec_counter = require('utils.dec_counter')
+local OSD = require('menu.osd_styler')
 
 --- Instead of comparing fields literally, normalize them to match different representations.
 local function normalize_field_content(new_text, old_text, cfg)
@@ -56,6 +58,73 @@ end
 local function make_exporter()
     local self = {}
     local pub = {}
+    local pending_mismatch_timer = nil
+    local confirm_mismatch_yes = "mpvacious-confirm-mismatched-notes-yes"
+    local confirm_mismatch_no = "mpvacious-confirm-mismatched-notes-no"
+    local mismatch_overlay = mp.create_osd_overlay and mp.create_osd_overlay('ass-events')
+    if mismatch_overlay then
+        mismatch_overlay.res_x = 1280
+        mismatch_overlay.res_y = 720
+        mismatch_overlay.z = 1000
+    end
+
+    local function clear_mismatch_confirmation()
+        mp.remove_key_binding(confirm_mismatch_yes)
+        mp.remove_key_binding(confirm_mismatch_no)
+        if mismatch_overlay then
+            mismatch_overlay:remove()
+        end
+        if pending_mismatch_timer then
+            pending_mismatch_timer:kill()
+            pending_mismatch_timer = nil
+        end
+    end
+
+    local function confirm_mismatched_notes(note_ids, overwrite, related_count)
+        clear_mismatch_confirmation()
+
+        local function cancel_update()
+            clear_mismatch_confirmation()
+            h.notify("Card update cancelled.", "info", 2)
+        end
+
+        local function proceed_with_update()
+            clear_mismatch_confirmation()
+            pub.update_notes(note_ids, overwrite)
+        end
+
+        mp.add_forced_key_binding("y", confirm_mismatch_yes, proceed_with_update)
+        mp.add_forced_key_binding("n", confirm_mismatch_no, cancel_update)
+        if mp.add_timeout then
+            pending_mismatch_timer = mp.add_timeout(10, cancel_update)
+        end
+        local warning = string.format(
+                "Only the newest %i of %i notes share %s.",
+                related_count,
+                #note_ids,
+                self.config.sentence_field
+        )
+        msg.warn(string.format("%s Update all %i anyway? [y] Yes [n] No", warning, #note_ids))
+        if mismatch_overlay then
+            mismatch_overlay.data = OSD:new()
+                    :new_layer()
+                    :align(5)
+                    :pos(640, 360)
+                    :border(3)
+                    :fsize(32)
+                    :red("Warning")
+                    :newline()
+                    :text(warning)
+                    :newline()
+                    :text(string.format("Update all %i anyway?", #note_ids))
+                    :newline()
+                    :item("[y] Yes")
+                    :text("      ")
+                    :item("[n] No")
+                    :get_text()
+            mismatch_overlay:update()
+        end
+    end
 
     local substitute_fmt = (function()
         local function substitute_filename(tag, filename)
@@ -361,6 +430,7 @@ local function make_exporter()
 
     function pub.update_last_note(overwrite)
         local accept_notes_made_within_last_minutes = 10
+        clear_mismatch_confirmation()
         pub.maybe_reload_config()
 
         local n_cards = self.quick_creation_opts:get_cards()
@@ -371,6 +441,33 @@ local function make_exporter()
         --first element is the earliest
         if h.is_empty(last_note_ids) or last_note_ids[1] < h.minutes_ago(accept_notes_made_within_last_minutes) then
             return h.notify("Couldn't find the target note.", "warn", 2)
+        end
+
+        if n_cards > 1 then
+            local newest_fields = self.ankiconnect.get_note_fields(last_note_ids[n_cards]) or {}
+            local newest_sentence = h.normalize_subtitle_text(newest_fields[self.config.sentence_field] or "")
+            if h.is_empty(newest_sentence) then
+                return h.notify(
+                        string.format("Couldn't verify related notes: newest note has an empty %s field.", self.config.sentence_field),
+                        "warn",
+                        4
+                )
+            end
+
+            local related_count = 1
+            for i = n_cards - 1, 1, -1 do
+                local fields = self.ankiconnect.get_note_fields(last_note_ids[i]) or {}
+                local sentence = h.normalize_subtitle_text(fields[self.config.sentence_field] or "")
+                if sentence ~= newest_sentence then
+                    break
+                end
+                related_count = related_count + 1
+            end
+
+            if related_count < n_cards then
+                confirm_mismatched_notes(last_note_ids, overwrite, related_count)
+                return pub
+            end
         end
 
         pub.update_notes(last_note_ids, overwrite)
@@ -483,6 +580,87 @@ local function make_exporter()
         h.assert_equals(make_new_note_data(old_note, new_note, { overwrite = false, disable_forvo = true }).SentKanji, expected.SentKanji)
     end
 
+    local function test_update_last_note_confirms_unrelated_notes()
+        local now_ms = os.time() * 1000
+        local note_ids = { now_ms - 5, now_ms - 4, now_ms - 3, now_ms - 2, now_ms - 1 }
+        local sentences = { "unrelated one", "unrelated two", "target", "<b>target</b>", "target" }
+        local updated = false
+        local notification = nil
+        local original_notify = h.notify
+        local original_add_key_binding = mp.add_forced_key_binding
+        local original_remove_key_binding = mp.remove_key_binding
+        local original_create_osd_overlay = mp.create_osd_overlay
+        local confirmation_bindings = {}
+        local confirmation_overlay = { update = function() return end, remove = function() return end }
+        h.notify = function(message)
+            notification = message
+        end
+        mp.add_forced_key_binding = function(key, _, fn)
+            confirmation_bindings[key] = fn
+        end
+        mp.remove_key_binding = function()
+            return
+        end
+        mp.create_osd_overlay = function()
+            return confirmation_overlay
+        end
+
+        local test_exporter = make_exporter().init(
+                {
+                    get_last_note_ids = function()
+                        return note_ids
+                    end,
+                    get_note_fields = function(note_id)
+                        for i, id in ipairs(note_ids) do
+                            if id == note_id then
+                                return { SentKanji = sentences[i] }
+                            end
+                        end
+                    end,
+                },
+                { get_cards = function() return 5 end },
+                nil,
+                nil,
+                nil,
+                {
+                    fail_if_not_ready = function() return end,
+                    config = function()
+                        return {
+                            sentence_field = "SentKanji",
+                            reload_config_before_card_creation = false,
+                        }
+                    end,
+                }
+        )
+        test_exporter.update_notes = function()
+            updated = true
+        end
+
+        test_exporter.update_last_note(false)
+        h.assert_equals(updated, false)
+        h.assert_equals(h.is_substr(confirmation_overlay.data, "Only the newest 3 of 5 notes share SentKanji."), true)
+        h.assert_equals(h.is_substr(confirmation_overlay.data, "Update all 5 anyway?"), true)
+        h.assert_equals(type(confirmation_bindings.y), "function")
+        h.assert_equals(type(confirmation_bindings.n), "function")
+
+        confirmation_bindings.y()
+        h.assert_equals(updated, true)
+
+        updated = false
+        test_exporter.update_last_note(false)
+        confirmation_bindings.n()
+        h.assert_equals(updated, false)
+        h.assert_equals(notification, "Card update cancelled.")
+
+        sentences[1], sentences[2] = "target", "target"
+        test_exporter.update_last_note(false)
+        h.assert_equals(updated, true)
+        h.notify = original_notify
+        mp.add_forced_key_binding = original_add_key_binding
+        mp.remove_key_binding = original_remove_key_binding
+        mp.create_osd_overlay = original_create_osd_overlay
+    end
+
     local function test_html_escaping()
         -- HTML escaping
         local old_note = {
@@ -503,6 +681,7 @@ local function make_exporter()
         test_html_escaping()
         test_join_fields_duplicates()
         test_make_new_note_data()
+        test_update_last_note_confirms_unrelated_notes()
         return pub
     end
 

--- a/mpvacious/anki/note_exporter.lua
+++ b/mpvacious/anki/note_exporter.lua
@@ -5,6 +5,7 @@ License: GNU GPL, version 3 or later; http://www.gnu.org/licenses/gpl.html
 
 local mp = require('mp')
 local h = require('helpers')
+local note_update_guard = require('anki.note_update_guard')
 local dec_counter = require('utils.dec_counter')
 
 --- Instead of comparing fields literally, normalize them to match different representations.
@@ -53,9 +54,18 @@ local function join_field_content(new_text, old_text, cfg)
     return string.format("%s%s%s", old_text, cfg.separator, new_text)
 end
 
-local function make_exporter()
+local function make_exporter(update_confirmation)
     local self = {}
     local pub = {}
+    local confirmation = update_confirmation or note_update_guard.new()
+
+    local function clear_update_state()
+        self.subs_observer.clear()
+        self.quick_creation_opts:clear_options()
+        if self.subs_observer.menu and self.subs_observer.menu.update then
+            self.subs_observer.menu:update()
+        end
+    end
 
     local substitute_fmt = (function()
         local function substitute_filename(tag, filename)
@@ -284,7 +294,7 @@ local function make_exporter()
         end
     end
 
-    function pub.update_notes(note_ids, overwrite)
+    local function collect_update_subtitle()
         local sub
         local n_lines = self.quick_creation_opts:get_lines()
         if n_lines then
@@ -292,11 +302,10 @@ local function make_exporter()
         else
             sub = self.subs_observer.collect_from_current()
         end
+        return sub
+    end
 
-        if not sub:is_valid() then
-            return h.notify("Nothing to export. Have you set the timings?", "warn", 2)
-        end
-
+    local function perform_update(note_ids, overwrite, sub)
         if h.is_empty(sub['text']) then
             -- In this case, don't modify whatever existing text there is and just
             -- modify the other fields we can. The user might be trying to add
@@ -317,8 +326,42 @@ local function make_exporter()
         snapshot.on_finish(create_files_countdown.decrease).run_async()
         audio.on_finish(create_files_countdown.decrease).run_async()
 
-        self.subs_observer.clear()
-        self.quick_creation_opts:clear_options()
+        clear_update_state()
+        return pub
+    end
+
+    function pub.update_notes(note_ids, overwrite, warnings)
+        local sub = collect_update_subtitle()
+        if not sub:is_valid() then
+            return h.notify("Nothing to export. Have you set the timings?", "warn", 2)
+        end
+
+        warnings = warnings or {}
+        local subtitle_warning = note_update_guard.current_subtitle_warning(
+                note_ids,
+                prepare_for_exporting(sub['text']),
+                self.config.sentence_field,
+                self.ankiconnect.get_note_fields
+        )
+        if subtitle_warning then
+            warnings[#warnings + 1] = subtitle_warning
+        end
+        if #warnings == 0 then
+            return perform_update(note_ids, overwrite, sub)
+        end
+
+        confirmation.confirm({
+            note_count = #note_ids,
+            field_name = self.config.sentence_field,
+            warning = table.concat(warnings, "\n"),
+            accepted = function()
+                perform_update(note_ids, overwrite, sub)
+            end,
+            cancelled = function()
+                clear_update_state()
+                h.notify("Card update cancelled.", "info", 2)
+            end,
+        })
         return pub
     end
 
@@ -362,6 +405,7 @@ local function make_exporter()
 
     function pub.update_last_note(overwrite)
         local accept_notes_made_within_last_minutes = 10
+        confirmation.close()
         pub.maybe_reload_config()
 
         local n_cards = self.quick_creation_opts:get_cards()
@@ -374,7 +418,15 @@ local function make_exporter()
             return h.notify("Couldn't find the target note.", "warn", 2)
         end
 
-        pub.update_notes(last_note_ids, overwrite)
+        local warning, error_message = note_update_guard.recent_notes_warning(
+                last_note_ids,
+                self.config.sentence_field,
+                self.ankiconnect.get_note_fields
+        )
+        if error_message then
+            return h.notify(error_message, "warn", 4)
+        end
+        pub.update_notes(last_note_ids, overwrite, warning and { warning } or nil)
         return pub
     end
 
@@ -502,9 +554,9 @@ local function test_make_new_note_data(test_exporter)
     h.assert_equals(test_exporter.make_new_note_data(old_note, new_note, { overwrite = false, disable_forvo = true }).SentKanji, expected.SentKanji)
 end
 
-local function valid_update_subtitle()
+local function update_subtitle(text)
     return {
-        text = "new sentence",
+        text = text,
         secondary = "",
         is_valid = function()
             return true
@@ -546,7 +598,8 @@ local UPDATE_TEST_CONFIG = {
     miscinfo_enable = false,
 }
 
-local function make_update_test_exporter(result, jobs)
+local function make_update_test_exporter(result, jobs, options)
+    options = options or {}
     local function append_media(note_id, fields)
         result.append_count = result.append_count + 1
         result.note_id = note_id
@@ -557,20 +610,31 @@ local function make_update_test_exporter(result, jobs)
             return "/tmp"
         end,
         get_note_fields = function()
-            return { SentKanji = "old sentence" }
+            return { SentKanji = options.stored_sentence or "new sentence" }
         end,
         append_media = append_media,
     }
     local quick_options = {
         get_lines = h.noop,
-        clear_options = h.noop
+        clear_options = function()
+            result.cleared = (result.cleared or 0) + 1
+        end,
     }
     local observer = {
-        collect_from_current = valid_update_subtitle,
+        collect_from_current = function()
+            return update_subtitle(options.current_sentence or "new sentence")
+        end,
         clipboard_prepare = function(text)
             return text
         end,
-        clear = h.noop,
+        clear = function()
+            result.cleared = (result.cleared or 0) + 1
+        end,
+        menu = {
+            update = function()
+                result.menu_updates = (result.menu_updates or 0) + 1
+            end,
+        },
     }
     local forvo = {
         set_output_dir = h.noop,
@@ -584,7 +648,7 @@ local function make_update_test_exporter(result, jobs)
             return UPDATE_TEST_CONFIG
         end
     }
-    return make_exporter().init(
+    return make_exporter(options.confirmation).init(
             ankiconnect,
             quick_options,
             observer,
@@ -592,6 +656,47 @@ local function make_update_test_exporter(result, jobs)
             forvo,
             config_manager
     )
+end
+
+local function test_mismatched_update_requires_confirmation()
+    local result = { append_count = 0 }
+    local jobs = {}
+    local confirmation = { close = h.noop }
+    confirmation.confirm = function(options)
+        result.confirmation = options
+    end
+    make_update_test_exporter(result, jobs, {
+        confirmation = confirmation,
+        current_sentence = 'それは うまくすれば 鉛から黄金を生み出すことも 可能になる',
+        stored_sentence = 'まあ 無理やり手伝った というのが正しいけれど それで稼いだお金よ',
+    }).update_notes({ 1 }, true)
+    h.assert_equals(#jobs, 0)
+    h.assert_equals(result.confirmation.field_name, 'SentKanji')
+    h.assert_equals(
+            result.confirmation.warning,
+            "The target note's SentKanji does not match the current subtitle."
+    )
+    result.confirmation.accepted()
+    h.assert_equals(#jobs, 2)
+    h.assert_equals(result.cleared, 2)
+end
+
+local function test_cancelled_update_clears_selection()
+    local result = { append_count = 0 }
+    local jobs = {}
+    local confirmation = { close = h.noop }
+    confirmation.confirm = function(options)
+        result.confirmation = options
+    end
+    make_update_test_exporter(result, jobs, {
+        confirmation = confirmation,
+        current_sentence = 'それは うまくすれば 鉛から黄金を生み出すことも 可能になる',
+        stored_sentence = 'まあ 無理やり手伝った というのが正しいけれど それで稼いだお金よ',
+    }).update_notes({ 1 }, true)
+    result.confirmation.cancelled()
+    h.assert_equals(#jobs, 0)
+    h.assert_equals(result.cleared, 2)
+    h.assert_equals(result.menu_updates, 1)
 end
 
 local function test_update_notes_after_media_created()
@@ -646,6 +751,8 @@ local function run_tests(test_exporter)
     test_join_fields_duplicates(test_exporter)
     test_make_new_note_data(test_exporter)
     test_update_notes_after_media_created()
+    test_mismatched_update_requires_confirmation()
+    test_cancelled_update_clears_selection()
 end
 
 return {

--- a/mpvacious/anki/note_update_guard.lua
+++ b/mpvacious/anki/note_update_guard.lua
@@ -1,0 +1,267 @@
+--[[
+Copyright: Ajatt-Tools and contributors; https://github.com/Ajatt-Tools
+License: GNU GPL, version 3 or later; http://www.gnu.org/licenses/gpl.html
+
+Note update guard verifies sentence identity and owns confirmation prompts.
+]]
+
+local h = require('helpers')
+
+local function normalize_sentence(text)
+    text = h.unescape_special_characters((text or ''):lower())
+    return h.normalize_subtitle_text(text)
+end
+
+local function sentences_are_related(first, second)
+    first, second = normalize_sentence(first), normalize_sentence(second)
+    return not h.is_empty(first)
+            and not h.is_empty(second)
+            and (h.is_substr(first, second) or h.is_substr(second, first))
+end
+
+local function sentence_field(note_id, field_name, get_note_fields)
+    local fields = get_note_fields(note_id) or {}
+    return fields[field_name] or ''
+end
+
+local function current_subtitle_warning(note_ids, current_sentence, field_name, get_note_fields)
+    if h.is_empty(current_sentence) then
+        return nil
+    end
+
+    local comparable_count = 0
+    local related_count = 0
+    for _, note_id in ipairs(note_ids) do
+        local stored_sentence = sentence_field(note_id, field_name, get_note_fields)
+        if not h.is_empty(normalize_sentence(stored_sentence)) then
+            comparable_count = comparable_count + 1
+            if sentences_are_related(current_sentence, stored_sentence) then
+                related_count = related_count + 1
+            end
+        end
+    end
+
+    if comparable_count == 0 or related_count == comparable_count then
+        return nil
+    elseif #note_ids == 1 then
+        return string.format("The target note's %s does not match the current subtitle.", field_name)
+    end
+    return string.format(
+            "Only %i of %i target notes have %s matching the current subtitle.",
+            related_count,
+            comparable_count,
+            field_name
+    )
+end
+
+local function recent_notes_warning(note_ids, field_name, get_note_fields)
+    if #note_ids < 2 then
+        return nil
+    end
+
+    local newest = normalize_sentence(sentence_field(note_ids[#note_ids], field_name, get_note_fields))
+    if h.is_empty(newest) then
+        return nil, string.format(
+                "Couldn't verify related notes: newest note has an empty %s field.",
+                field_name
+        )
+    end
+
+    local related_count = 1
+    for i = #note_ids - 1, 1, -1 do
+        if normalize_sentence(sentence_field(note_ids[i], field_name, get_note_fields)) ~= newest then
+            break
+        end
+        related_count = related_count + 1
+    end
+    if related_count < #note_ids then
+        return string.format(
+                "Only the newest %i of %i notes share %s.",
+                related_count,
+                #note_ids,
+                field_name
+        )
+    end
+    return nil
+end
+
+local function new(dependencies)
+    dependencies = dependencies or {
+        input = require('mp.input'),
+        logger = require('mp.msg'),
+        mp = require('mp'),
+    }
+    local active
+
+    local function close()
+        if not active then
+            return
+        end
+        if active.timer then
+            active.timer:kill()
+        end
+        active = nil
+        dependencies.input.terminate()
+    end
+
+    local function confirm(options)
+        close()
+        local confirmation = {}
+        active = confirmation
+
+        local function finish(confirmed)
+            if active ~= confirmation then
+                return
+            end
+            close()
+            if confirmed then
+                options.accepted()
+            else
+                options.cancelled()
+            end
+        end
+
+        local question = options.note_count == 1
+                and "Update this note anyway?"
+                or string.format("Update all %i notes anyway?", options.note_count)
+        confirmation.timer = dependencies.mp.add_timeout(10, function()
+            finish(false)
+        end)
+        dependencies.input.select({
+            prompt = string.format("Warning: %s mismatch. %s", options.field_name, question),
+            items = { "Yes", "No" },
+            default_item = 2,
+            submit = function(index)
+                finish(index == 1)
+            end,
+            closed = function()
+                finish(false)
+            end,
+        })
+        dependencies.logger.warn(string.format("%s %s", options.warning, question))
+    end
+
+    return {
+        close = close,
+        confirm = confirm,
+    }
+end
+
+local function note_fields(sentences)
+    return function(note_id)
+        return { SentKanji = sentences[note_id] }
+    end
+end
+
+local function test_sentence_relationship()
+    local sentence = "それは うまくすれば 鉛から黄金を生み出すことも 可能になる"
+    h.assert_equals(sentences_are_related(sentence, "鉛から<b>黄金</b>を生み出すことも"), true)
+    h.assert_equals(sentences_are_related(sentence, "まあ 無理やり手伝った というのが正しい"), false)
+    h.assert_equals(sentences_are_related('', sentence), false)
+end
+
+local function test_current_subtitle_warning()
+    local sentence = 'それは うまくすれば 鉛から黄金を生み出すことも 可能になる'
+    local unrelated = 'まあ 無理やり手伝った というのが正しいけれど それで稼いだお金よ'
+    local cases = {
+        { ids = { 1 }, stored = { [1] = '鉛から<b>黄金</b>を生み出すことも' }, expected = nil },
+        {
+            ids = { 1 },
+            stored = { [1] = unrelated },
+            expected = "The target note's SentKanji does not match the current subtitle.",
+        },
+        {
+            ids = { 1, 2 },
+            stored = { [1] = sentence, [2] = unrelated },
+            expected = 'Only 1 of 2 target notes have SentKanji matching the current subtitle.',
+        },
+    }
+    for _, case in ipairs(cases) do
+        h.assert_equals(
+                current_subtitle_warning(case.ids, sentence, 'SentKanji', note_fields(case.stored)),
+                case.expected
+        )
+    end
+end
+
+local function test_recent_notes_warning()
+    local ids = { 1, 2, 3, 4, 5 }
+    local warning = recent_notes_warning(
+            ids,
+            'SentKanji',
+            note_fields({ 'unrelated one', 'unrelated two', 'target', '<b>target</b>', 'target' })
+    )
+    h.assert_equals(warning, 'Only the newest 3 of 5 notes share SentKanji.')
+    h.assert_equals(recent_notes_warning(ids, 'SentKanji', note_fields({ 'target', 'target', 'target', 'target', 'target' })), nil)
+    local _, err = recent_notes_warning(ids, 'SentKanji', note_fields({ 'target', 'target', 'target', 'target', '' }))
+    h.assert_equals(err, "Couldn't verify related notes: newest note has an empty SentKanji field.")
+end
+
+local function confirmation_fixture()
+    local state = { accepted = 0, cancelled = 0, terminated = 0, timer_kills = 0 }
+    local dependencies = {
+        input = {
+            select = function(options)
+                state.options = options
+            end,
+            terminate = function()
+                state.terminated = state.terminated + 1
+            end,
+        },
+        logger = {
+            warn = function(message)
+                state.warning = message
+            end,
+        },
+        mp = {
+            add_timeout = function(_, callback)
+                state.timeout = callback
+                return { kill = function() state.timer_kills = state.timer_kills + 1 end }
+            end,
+        },
+    }
+    local confirmation = new(dependencies)
+    confirmation.confirm({
+        note_count = 1,
+        field_name = 'SentKanji',
+        warning = 'Different sentence.',
+        accepted = function()
+            state.accepted = state.accepted + 1
+        end,
+        cancelled = function()
+            state.cancelled = state.cancelled + 1
+        end,
+    })
+    return state
+end
+
+local function test_confirmation_lifecycle()
+    local accepted = confirmation_fixture()
+    h.assert_equals(accepted.options.items, { 'Yes', 'No' })
+    h.assert_equals(accepted.options.default_item, 2)
+    h.assert_equals(accepted.options.prompt, 'Warning: SentKanji mismatch. Update this note anyway?')
+    accepted.options.submit(1)
+    accepted.options.closed()
+    h.assert_equals({ accepted.accepted, accepted.cancelled }, { 1, 0 })
+    h.assert_equals({ accepted.terminated, accepted.timer_kills }, { 1, 1 })
+
+    local cancelled = confirmation_fixture()
+    cancelled.timeout()
+    h.assert_equals({ cancelled.accepted, cancelled.cancelled }, { 0, 1 })
+    h.assert_equals({ cancelled.terminated, cancelled.timer_kills }, { 1, 1 })
+end
+
+local function run_tests()
+    test_sentence_relationship()
+    test_current_subtitle_warning()
+    test_recent_notes_warning()
+    test_confirmation_lifecycle()
+end
+
+return {
+    current_subtitle_warning = current_subtitle_warning,
+    new = new,
+    recent_notes_warning = recent_notes_warning,
+    run_tests = run_tests,
+    sentences_are_related = sentences_are_related,
+}

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -16,6 +16,7 @@ local modules = {
     'encoder.utils',
     'config.utils',
     'anki.note_exporter',
+    'anki.note_update_guard',
     'subtitles.subtitle',
     'subtitles.collector',
     'subtitles.sub_list',

--- a/tests/setup.lua
+++ b/tests/setup.lua
@@ -197,8 +197,14 @@ local mp_options_stub = {
     read_options = noop,
 }
 
+local mp_input_stub = {
+    select = noop,
+    terminate = noop,
+}
+
 -- Register stubs before any mpvacious module is required.
 package.loaded['mp'] = mp_stub
 package.loaded['mp.msg'] = mp_msg_stub
 package.loaded['mp.utils'] = mp_utils_stub
 package.loaded['mp.options'] = mp_options_stub
+package.loaded['mp.input'] = mp_input_stub


### PR DESCRIPTION
## Problem

When updating recent Anki notes, mpvacious trusts the configured card count.
If that count is too high, it can overwrite older notes that belong to a
different sentence.

### Example

Suppose the card count is set to 3, but you created only one card for the
current subtitle. Two unrelated cards are still inside the ten-minute update
window. Mpvacious currently treats all three as targets and can overwrite the
two older cards.

The same problem can happen with a single card if the most recent note belongs
to a different subtitle.

## Change

- Compare the configured sentence field before updating recent notes.
- Ignore differences caused only by HTML markup or spacing.
- If the notes appear unrelated, show a Yes/No prompt using
  `mp.input.select`.
- Default to No and cancel if the prompt is dismissed or left unanswered for
  ten seconds.
- Continue with the update only when the user explicitly chooses Yes.

This keeps intentional updates possible while protecting unrelated notes from
accidental changes.

## Tests

Added tests for multi-card mismatches, single-card mismatches, confirmation,
cancellation, timeout handling, and duplicate callbacks.

The full test suite passes with `luajit tests/run.lua`.
