### PR TITLE
replace menu_max_shown_line_length with menu_max_shown_lines

### DIFF
--- a/mpvacious/config/default_config.conf
+++ b/mpvacious/config/default_config.conf
@@ -38,11 +38,10 @@ note_tag=subs2srs
 menu_font_size=24
 menu_font_name=Noto Sans CJK JP
 
-# Maximum display width of a subtitle line in the menus before truncating.
-# CJK characters count as 2 width units, narrower characters as 1.
-# An ellipsis ("…") is appended when truncating.
-# Values are clamped to the supported range: 5-200.
-menu_max_shown_line_length=60
+# Maximum number of wrapped lines shown per recorded subtitle in the menu's second pane.
+# If the text needs more lines, the last shown line ends with an ellipsis ("…").
+# Values are clamped to the supported range: 1-20.
+menu_max_shown_lines=1
 
 # AnkiConnect server address
 # The default address for a server on the same device is http://127.0.0.1:8765.

--- a/mpvacious/config/defaults.lua
+++ b/mpvacious/config/defaults.lua
@@ -23,11 +23,11 @@ this.default_height_px = 350
 -- Measure quality from 0 (worst/lowest) to 100 (best/highest)
 this.default_image_quality = 15
 
--- Menu line length limits (display width units).
+-- Maximum number of wrapped lines shown per recorded subtitle in the menu's second pane.
 -- Values outside this range are clamped during config validation.
-this.min_menu_max_shown_line_length = 5
-this.default_menu_max_shown_line_length = 60
-this.max_menu_max_shown_line_length = 200
+this.min_menu_max_shown_lines = 1
+this.default_menu_max_shown_lines = 1
+this.max_menu_max_shown_lines = 20
 
 this.get_default = function()
     return {
@@ -79,7 +79,7 @@ this.get_default = function()
         -- Menu
         menu_font_name = "Noto Sans CJK JP",
         menu_font_size = 25,
-        menu_max_shown_line_length = this.default_menu_max_shown_line_length,
+        menu_max_shown_lines = this.default_menu_max_shown_lines,
         show_selected_text = true,
 
         -- Make sure to remove loudnorm from ffmpeg_audio_args and mpv_audio_args before enabling.

--- a/mpvacious/config/utils.lua
+++ b/mpvacious/config/utils.lua
@@ -135,10 +135,10 @@ local function validate_config(config)
     end
 
     local function check_menu_settings()
-        config.menu_max_shown_line_length = h.clamp(
-                config.menu_max_shown_line_length,
-                defaults.min_menu_max_shown_line_length,
-                defaults.max_menu_max_shown_line_length
+        config.menu_max_shown_lines = h.clamp(
+                config.menu_max_shown_lines,
+                defaults.min_menu_max_shown_lines,
+                defaults.max_menu_max_shown_lines
         )
     end
 
@@ -153,24 +153,24 @@ local function validate_config(config)
 end
 
 local function run_tests()
-    local function validate_menu_line_limit(value)
+    local function validate_menu_max_shown_lines(value)
         local config = defaults.get_default()
-        config.menu_max_shown_line_length = value
+        config.menu_max_shown_lines = value
         validate_config(config)
-        return config.menu_max_shown_line_length
+        return config.menu_max_shown_lines
     end
 
     local cases = {
-        { -10, defaults.min_menu_max_shown_line_length },
-        { defaults.min_menu_max_shown_line_length, defaults.min_menu_max_shown_line_length },
-        { defaults.default_menu_max_shown_line_length, defaults.default_menu_max_shown_line_length },
-        { defaults.max_menu_max_shown_line_length, defaults.max_menu_max_shown_line_length },
-        { 9999, defaults.max_menu_max_shown_line_length },
+        { -10, defaults.min_menu_max_shown_lines },
+        { defaults.min_menu_max_shown_lines, defaults.min_menu_max_shown_lines },
+        { defaults.default_menu_max_shown_lines, defaults.default_menu_max_shown_lines },
+        { defaults.max_menu_max_shown_lines, defaults.max_menu_max_shown_lines },
+        { 9999, defaults.max_menu_max_shown_lines },
     }
 
     for _, case in ipairs(cases) do
         local value, expected = h.unpack(case)
-        h.assert_equals(validate_menu_line_limit(value), expected)
+        h.assert_equals(validate_menu_max_shown_lines(value), expected)
     end
 end
 

--- a/mpvacious/helpers.lua
+++ b/mpvacious/helpers.lua
@@ -200,6 +200,16 @@ function this.split_lines(str)
     return lines
 end
 
+--- Keep at most max_lines lines, appending "…" to the last kept line if any were dropped.
+function this.limit_lines(lines, max_lines)
+    if #lines <= max_lines then
+        return lines
+    end
+    local kept = this.itable_slice(lines, 1, max_lines)
+    kept[#kept] = kept[#kept] .. "…"
+    return kept
+end
+
 function this.normalize_spaces(str)
     -- Replace sequences of ASCII spaces or full-width ideographic spaces with a single ASCII space.
     return str:gsub('　+', ' '):gsub('  +', " ")
@@ -941,6 +951,21 @@ local function test_split_lines()
     end
 end
 
+local function test_limit_lines()
+    local limit_lines_cases = {
+        -- {lines, max_lines, expected}
+        { { "a", "b" }, 3, { "a", "b" } }, -- under the limit: unchanged
+        { { "a", "b" }, 2, { "a", "b" } }, -- exactly at the limit: unchanged
+        { { "a", "b", "c" }, 2, { "a", "b…" } }, -- over the limit: capped, ellipsis on the last kept line
+        { { "a", "b", "c" }, 1, { "a…" } }, -- limit of one line
+        { {}, 2, {} }, -- empty input
+    }
+    for _, case in ipairs(limit_lines_cases) do
+        local lines, max_lines, expected = this.unpack(case)
+        this.assert_equals(this.limit_lines(lines, max_lines), expected)
+    end
+end
+
 local function test_str_wrap()
     local str_wrap_cases = {
         { text = "short", n_chars = 25, separator = [[\N]], expected = "short" },
@@ -1148,6 +1173,9 @@ function this.run_tests()
 
     -- Test split_lines
     test_split_lines()
+
+    -- Test limit_lines
+    test_limit_lines()
 
     -- Test str wrap
     test_str_wrap()

--- a/mpvacious/main.lua
+++ b/mpvacious/main.lua
@@ -112,23 +112,33 @@ local function _run(params)
     end
 end
 
---- Trim, strip OSD-special characters, and limit the string
---- to a display width of menu_max_shown_line_length for the menus.
---- CJK characters count as 2 width units, narrower characters as 1.
---- An ellipsis ("…") is appended when truncating.
+--- Number of display width units that fit in a menu pane at the current font size.
+--- One unit is approximately half an em; a pane is start_x_second_pane ASS pixels wide.
+local function menu_line_width()
+    return math.floor(menu_consts.start_x_second_pane * 2 / cfg_mgr.query("menu_font_size"))
+end
+
+--- Trim and strip OSD-special characters for display in the menus.
 local function escape_for_osd(str)
     str = h.trim(str)
     str = str:gsub('[%[%]{}]', '')
-    return h.str_limit_width(str, cfg_mgr.query("menu_max_shown_line_length"))
+    return str
+end
+
+--- Flatten a subtitle to one line and width-limit it for the subs selector.
+--- An ellipsis ("…") is appended when truncating.
+local function limit_selector_line(str)
+    return h.str_limit_width(escape_for_osd(h.remove_newlines(str)), menu_line_width())
 end
 
 --- Flatten subtitle text for the OSD second pane and wrap it to the pane width.
---- Newlines are replaced with spaces so each recorded sub renders on one line;
---- the flat string is then width-limited and wrapped to fit the pane.
+--- Newlines are replaced with spaces so each recorded sub renders as one entry;
+--- the entry is wrapped to the pane width and capped at menu_max_shown_lines lines,
+--- with an ellipsis ("…") on the last shown line when capped.
 local function wrap_selected_for_osd(str)
     str = escape_for_osd(h.remove_newlines(str))
-    local wrap_width = math.floor(menu_consts.start_x_second_pane * 2 / cfg_mgr.query("menu_font_size"))
-    return h.str_wrap(str, wrap_width, [[\N]])
+    local wrapped_lines = h.limit_lines(h.str_to_lines(str, menu_line_width()), cfg_mgr.query("menu_max_shown_lines"))
+    return table.concat(wrapped_lines, [[\N]])
 end
 
 local function ensure_deck()
@@ -476,9 +486,9 @@ function subs_menu:print_subs_selector(osd)
     for _, item in ipairs(subs_menu.subs_selector.adjacent_items(5, 5)) do
         local checkbox = subs_menu.chosen_subs[item.idx] and "[x]" or "[ ]"
         if item.idx == subs_menu.subs_selector.get_index() then
-            osd:tab():blue(checkbox):text(' <'):blue(escape_for_osd(item.item.text)):text('>'):newline()
+            osd:tab():blue(checkbox):text(' <'):blue(limit_selector_line(item.item.text)):text('>'):newline()
         else
-            osd:tab():item(checkbox):text(' <'):text(escape_for_osd(item.item.text)):text('>'):newline()
+            osd:tab():item(checkbox):text(' <'):text(limit_selector_line(item.item.text)):text('>'):newline()
         end
     end
     osd:submenu('Controls'):newline()


### PR DESCRIPTION
With a limit on the number of characters shown per subtitle line, a subtitle line can often end up wrapped and then truncated in the middle. So I think it is better to always truncate at line boundaries. @kuator

Maybe we can even remove menu_max_shown_lines and always set it to 1.