### PR TITLE
fix: call exported note data helper

### DIFF
--- a/mpvacious/anki/note_exporter.lua
+++ b/mpvacious/anki/note_exporter.lua
@@ -276,7 +276,7 @@ local function make_exporter()
         for _, note_id in pairs(note_ids) do
             self.ankiconnect.append_media(
                     note_id,
-                    make_new_note_data(self.ankiconnect.get_note_fields(note_id), h.deep_copy(new_data), { overwrite = overwrite }),
+                    pub.make_new_note_data(self.ankiconnect.get_note_fields(note_id), h.deep_copy(new_data), { overwrite = overwrite }),
                     substitute_fmt(self.config.note_tag),
                     change_notes_countdown.decrease
             )
@@ -501,6 +501,67 @@ local function test_make_new_note_data(test_exporter)
     h.assert_equals(test_exporter.make_new_note_data(old_note, new_note, { overwrite = false, disable_forvo = true }).SentKanji, expected.SentKanji)
 end
 
+local function test_update_notes_after_media_created()
+    local updated_fields
+
+    local function make_media_job()
+        local job = { filename = nil }
+        job.on_finish = function(callback)
+            job.callback = callback
+            return job
+        end
+        job.run_async = function()
+            job.callback()
+        end
+        return job
+    end
+
+    local test_exporter = make_exporter().init(
+            {
+                get_media_dir_path = function() return "/tmp" end,
+                get_note_fields = function() return { SentKanji = "old sentence" } end,
+                append_media = function(_, fields) updated_fields = fields end,
+            },
+            {
+                get_lines = function() return nil end,
+                clear_options = h.noop,
+            },
+            {
+                collect_from_current = function()
+                    return {
+                        text = "new sentence",
+                        secondary = "",
+                        is_valid = function() return true end,
+                    }
+                end,
+                clipboard_prepare = function(text) return text end,
+                clear = h.noop,
+            },
+            {
+                set_output_dir = h.noop,
+                snapshot = { create_job = make_media_job },
+                audio = { create_job = make_media_job },
+            },
+            {
+                set_output_dir = h.noop,
+                append = function(new_data) return new_data end,
+            },
+            {
+                fail_if_not_ready = h.noop,
+                config = function()
+                    return {
+                        sentence_field = "SentKanji",
+                        audio_padding = 0,
+                        miscinfo_enable = false,
+                    }
+                end,
+            }
+    )
+
+    test_exporter.update_notes({ 1 }, true)
+    h.assert_equals(updated_fields.SentKanji, "new sentence")
+end
+
 local function make_test_exporter()
     local test_cfg_mgr = {
         fail_if_not_ready = h.noop,
@@ -537,6 +598,7 @@ local function run_tests(test_exporter)
     test_html_escaping(test_exporter)
     test_join_fields_duplicates(test_exporter)
     test_make_new_note_data(test_exporter)
+    test_update_notes_after_media_created()
 end
 
 return {

--- a/mpvacious/anki/note_exporter.lua
+++ b/mpvacious/anki/note_exporter.lua
@@ -245,7 +245,8 @@ local function make_exporter()
         return new_data
     end
 
-    --- expected cfg fields: bool disable_forvo, bool overwrite
+    --- Merge generated note fields with stored fields according to update options.
+    --- cfg.disable_forvo skips pronunciation media; cfg.overwrite replaces rather than appends.
     function pub.make_new_note_data(stored_data, new_data, cfg)
         cfg = cfg or {}
 
@@ -501,65 +502,111 @@ local function test_make_new_note_data(test_exporter)
     h.assert_equals(test_exporter.make_new_note_data(old_note, new_note, { overwrite = false, disable_forvo = true }).SentKanji, expected.SentKanji)
 end
 
-local function test_update_notes_after_media_created()
-    local updated_fields
+local function valid_update_subtitle()
+    return {
+        text = "new sentence",
+        secondary = "",
+        is_valid = function()
+            return true
+        end,
+    }
+end
 
-    local function make_media_job()
-        local job = { filename = nil }
-        job.on_finish = function(callback)
-            job.callback = callback
-            return job
-        end
-        job.run_async = function()
-            job.callback()
-        end
+local function make_pending_media_job(filename, jobs)
+    local job = { filename = filename, run_async = h.noop }
+    function job.on_finish(callback)
+        job.callback = callback
         return job
     end
+    table.insert(jobs, job)
+    return job
+end
 
-    local test_exporter = make_exporter().init(
-            {
-                get_media_dir_path = function() return "/tmp" end,
-                get_note_fields = function() return { SentKanji = "old sentence" } end,
-                append_media = function(_, fields) updated_fields = fields end,
-            },
-            {
-                get_lines = function() return nil end,
-                clear_options = h.noop,
-            },
-            {
-                collect_from_current = function()
-                    return {
-                        text = "new sentence",
-                        secondary = "",
-                        is_valid = function() return true end,
-                    }
-                end,
-                clipboard_prepare = function(text) return text end,
-                clear = h.noop,
-            },
-            {
-                set_output_dir = h.noop,
-                snapshot = { create_job = make_media_job },
-                audio = { create_job = make_media_job },
-            },
-            {
-                set_output_dir = h.noop,
-                append = function(new_data) return new_data end,
-            },
-            {
-                fail_if_not_ready = h.noop,
-                config = function()
-                    return {
-                        sentence_field = "SentKanji",
-                        audio_padding = 0,
-                        miscinfo_enable = false,
-                    }
-                end,
-            }
+local function make_media_job_factory(filename, jobs)
+    return function()
+        return make_pending_media_job(filename, jobs)
+    end
+end
+
+local function make_update_test_encoder(jobs)
+    return {
+        set_output_dir = h.noop,
+        snapshot = { create_job = make_media_job_factory("snapshot.avif", jobs) },
+        audio = { create_job = make_media_job_factory("audio.ogg", jobs) },
+    }
+end
+
+local UPDATE_TEST_CONFIG = {
+    sentence_field = "SentKanji",
+    audio_field = "SentAudio",
+    audio_template = "[sound:%s]",
+    image_field = "Image",
+    image_template = '<img alt="snapshot" src="%s">',
+    audio_padding = 0,
+    miscinfo_enable = false,
+}
+
+local function make_update_test_exporter(result, jobs)
+    local function append_media(note_id, fields)
+        result.append_count = result.append_count + 1
+        result.note_id = note_id
+        result.fields = fields
+    end
+    local ankiconnect = {
+        get_media_dir_path = function()
+            return "/tmp"
+        end,
+        get_note_fields = function()
+            return { SentKanji = "old sentence" }
+        end,
+        append_media = append_media,
+    }
+    local quick_options = {
+        get_lines = h.noop,
+        clear_options = h.noop
+    }
+    local observer = {
+        collect_from_current = valid_update_subtitle,
+        clipboard_prepare = function(text)
+            return text
+        end,
+        clear = h.noop,
+    }
+    local forvo = {
+        set_output_dir = h.noop,
+        append = function(new_data)
+            return new_data
+        end
+    }
+    local config_manager = {
+        fail_if_not_ready = h.noop,
+        config = function()
+            return UPDATE_TEST_CONFIG
+        end
+    }
+    return make_exporter().init(
+            ankiconnect,
+            quick_options,
+            observer,
+            make_update_test_encoder(jobs),
+            forvo,
+            config_manager
     )
+end
 
-    test_exporter.update_notes({ 1 }, true)
-    h.assert_equals(updated_fields.SentKanji, "new sentence")
+local function test_update_notes_after_media_created()
+    local result = { append_count = 0 }
+    local jobs = {}
+    make_update_test_exporter(result, jobs).update_notes({ 1 }, true)
+    h.assert_equals(#jobs, 2)
+    jobs[1].callback()
+    h.assert_equals(result.append_count, 0)
+    jobs[2].callback()
+    h.assert_equals(result.append_count, 1)
+    h.assert_equals(result.note_id, 1)
+    h.assert_equals(result.fields.SentKanji, "new sentence")
+    h.assert_equals(result.fields.SentAudio, "[sound:audio.ogg]")
+    h.assert_equals(result.fields.Image, '<img alt="snapshot" src="snapshot.avif">')
 end
 
 local function make_test_exporter()

--- a/mpvacious/helpers.lua
+++ b/mpvacious/helpers.lua
@@ -18,7 +18,7 @@ local CharWidth = {
 }
 
 function this.noop()
-    return
+    return nil
 end
 
 function this.remove_all_spaces(str)


### PR DESCRIPTION
## Problem

Updating an existing Anki note crashes after the snapshot and audio jobs
finish:

```text
attempt to call global 'make_new_note_data' (a nil value)
```

`make_new_note_data` was moved to the exporter table as
`pub.make_new_note_data`, but the asynchronous update callback still calls it
by its old local name.

## Fix

Call `pub.make_new_note_data` from the callback.

## Test

Added a regression test that runs both media completion callbacks and verifies
that the generated fields are passed to `append_media`. The old code fails this
test with the same nil-function error seen in mpv.

## Verification

- `luajit tests/run.lua`
